### PR TITLE
link to GitHub repo in header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,6 +21,9 @@
       <li class="{% if page.url contains '/docs/' %}active{% endif %}">
         <a href="{{ site.baseurl }}/docs/">Documentation</a>
       </li>
+      <li>
+        <a href="https://github.com/nylas/N1">Source Code</a>
+      </li>
     </ul>
     <div class="alt-nav-actions">
       <ul>


### PR DESCRIPTION
Having a link to a GitHub repo in the header automatically conveys to visitors this is an open-source project. This above-fold link is good validation for new visitors. It would be better with the GitHub logo using a font icon, but I'm not sure which static assets you have available.