### PR TITLE
Add basic travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+sudo: true
+before_install:
+  - sudo apt-get install libgnome-keyring-dev
+install:
+  - ./script/bootstrap
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
+node_js:
+  - "0.10"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "packageDependencies": {},
   "private": true,
   "scripts": {
+    "test": "./N1.sh --test",
     "preinstall": "node -e 'process.exit(0)'"
   }
 }


### PR DESCRIPTION
Adds travis-ci integration including setup, building and testing your specs. Though this is currently not succeeding on Node 4 this might be a good idea to run continuous integration tests on this fabulous peace of software.