### PR TITLE
Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
-language: node_js
-sudo: true
-before_install:
-  - sudo apt-get install libgnome-keyring-dev
-install:
-  - ./script/bootstrap
-env:
-  - CXX=g++-4.8
+matrix:
+  include:
+    - os: linux
+    - os: osx
+
+sudo: false
+
+script: script/cibuild
+
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
-    - g++-4.8
+    - libgnome-keyring-dev
+
 node_js:
   - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+env:
+  global:
+    - NYLAS_ACCESS_TOKEN=7740641a9b32bac91c5b3cd60633071887a07eee
+
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ env:
   global:
     - NYLAS_ACCESS_TOKEN=cb200be7c921f73a1c35930f6a4ac8758b271be0
 
+compiler: clang
+
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - NYLAS_ACCESS_TOKEN=7740641a9b32bac91c5b3cd60633071887a07eee
+    - NYLAS_ACCESS_TOKEN=3d954b69a7b74a5086f51e0e1b8403885246b598
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: NODE_VERSION=0.10
     - os: linux
       env: NODE_VERSION=0.12
-    - os: linux
-      env: NODE_VERSION=4
     - os: osx
       env: NODE_VERSION=0.10
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,25 @@
-language: node_js
-node_js:
-  - "4.1"
-  - "4.0"
-  - "0.12"
-  - "0.10"
-
 matrix:
   include:
     - os: linux
+      env: NODE_VERSION=0.10
+    - os: linux
+      env: NODE_VERSION=0.12
+    - os: linux
+      env: NODE_VERSION=4
     - os: osx
+      env: NODE_VERSION=0.10
+    - os: osx
+      env: NODE_VERSION=0.12
+    - os: osx
+      env: NODE_VERSION=4
 
 sudo: false
+
+install:
+  - git clone https://github.com/creationix/nvm.git /tmp/.nvm
+  - source /tmp/.nvm/nvm.sh
+  - nvm install $NODE_VERSION
+  - nvm use $NODE_VERSION
 
 script: script/cibuild
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,7 @@ script: script/cibuild
 addons:
   apt:
     packages:
+    - build-essential
+    - git
     - libgnome-keyring-dev
+    - fakeroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - NYLAS_ACCESS_TOKEN=3d954b69a7b74a5086f51e0e1b8403885246b598
+    - NYLAS_ACCESS_TOKEN=cb200be7c921f73a1c35930f6a4ac8758b271be0
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: NODE_VERSION=0.10
     - os: osx
       env: NODE_VERSION=0.12
-    - os: osx
-      env: NODE_VERSION=4
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+language: node_js
+node_js:
+  - "4.1"
+  - "4.0"
+  - "0.12"
+  - "0.10"
+
 matrix:
   include:
     - os: linux
@@ -11,6 +18,3 @@ addons:
   apt:
     packages:
     - libgnome-keyring-dev
-
-node_js:
-  - "0.10"

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -325,7 +325,7 @@ module.exports = (grunt) ->
   ciTasks.push('set-version', 'lint', 'generate-asar')
   ciTasks.push('mkdeb') if process.platform is 'linux'
   ciTasks.push('test') if process.platform is 'darwin'
-  ciTasks.push('codesign')
+  ciTasks.push('codesign') unless process.env.TRAVIS
   ciTasks.push('mkdmg') if process.platform is 'darwin'
   ciTasks.push('create-windows-installer') if process.platform is 'win32'
   # ciTasks.push('publish-docs') if process.platform is 'darwin'

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -326,10 +326,10 @@ module.exports = (grunt) ->
   ciTasks.push('mkdeb') if process.platform is 'linux'
   ciTasks.push('test') if process.platform is 'darwin'
   ciTasks.push('codesign') unless process.env.TRAVIS
-  ciTasks.push('mkdmg') if process.platform is 'darwin'
-  ciTasks.push('create-windows-installer') if process.platform is 'win32'
-  # ciTasks.push('publish-docs') if process.platform is 'darwin'
-  ciTasks.push('publish-nylas-build') if process.platform is 'darwin'
+  ciTasks.push('mkdmg') if process.platform is 'darwin' and not process.env.TRAVIS
+  ciTasks.push('create-windows-installer') if process.platform is 'win32' and not process.env.TRAVIS
+  # ciTasks.push('publish-docs') if process.platform is 'darwin' and not process.env.TRAVIS
+  ciTasks.push('publish-nylas-build') if process.platform is 'darwin' and not process.env.TRAVIS
   grunt.registerTask('ci', ciTasks)
 
   defaultTasks = ['download-electron', 'build', 'set-version', 'generate-asar']

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -297,7 +297,7 @@ module.exports = (grunt) ->
       outputDir: 'electron'
       downloadDir: electronDownloadDir
       rebuild: true  # rebuild native modules after electron is updated
-      token: process.env.ATOM_ACCESS_TOKEN
+      token: process.env.NYLAS_ACCESS_TOKEN
 
     'create-windows-installer':
       appDirectory: shellAppDir

--- a/src/flux/models/label.coffee
+++ b/src/flux/models/label.coffee
@@ -16,7 +16,7 @@ While the two appear fairly similar, they have different behavioral
 semantics and are treated separately.
 
 Nylas also exposes a set of standard types or categories of folders/
-labels: an extended version of [rfc-6154](http://tools.ietf.org/html/rfc6154), 
+labels: an extended version of [rfc-6154](http://tools.ietf.org/html/rfc6154),
 returned as the name of the folder/
 label:
   - inbox


### PR DESCRIPTION
I noticed on the official N1 travis page it succeeded, but the actual spec tester failed run because it couldn't connect to a X11 display. I took the liberty of revamping the travis build script to follow Atom's example and build separately on Linux and OS X.

The Linux build is still having issues, but I do not know how they are occurring. I probably will setup a Ubuntu Precise box just to solve the issues. The OS X build completes spectacularly with the spec test being run, and all of them passing.

EDIT: The Travis script uses a developer Github API OAuth key. Just follow the instructions at https://developer.github.com/v3/oauth/ to get a access token. Or continue using the one I generated.