### PR TITLE
Added eas_server_host field

### DIFF
--- a/internal_packages/onboarding/lib/account-types.coffee
+++ b/internal_packages/onboarding/lib/account-types.coffee
@@ -38,6 +38,11 @@ Providers = [
         type: 'password'
         placeholder: 'Password'
         label: 'Password'
+      }, {
+          name: 'eas_server_host'
+          type: 'text'
+          placeholder: 'mail.company.com'
+          label: 'Exchange server (optional)'
       }
     ]
   }, {


### PR DESCRIPTION
eas_server_host field added to internal_packages/onboarding/account-types.coffee to allow for specifying the Exchange server if necessary.