### PR TITLE
Rename some variables from atom to nylas

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -4,8 +4,8 @@ os = require 'os'
 
 # This is the main Gruntfile that manages building N1 distributions.
 # The reason it's inisde of the build/ folder is so everything can be
-# compiled against Node's v8 headers instead of Atom's v8 headers. All
-# packages in the root-level node_modules are compiled against Atom's v8
+# compiled against Node's v8 headers instead of Electron's v8 headers. All
+# packages in the root-level node_modules are compiled against Electron's v8
 # headers.
 #
 # Some useful grunt options are:
@@ -173,7 +173,7 @@ module.exports = (grunt) ->
       continue unless grunt.file.isFile(metadataPath)
 
       {engines, theme} = grunt.file.readJSON(metadataPath)
-      if engines?.atom?
+      if engines?.nylas?
         coffeeConfig.glob_to_multiple.src.push("#{directory}/**/*.coffee")
         lessConfig.glob_to_multiple.src.push("#{directory}/**/*.less")
         prebuildLessConfig.src.push("#{directory}/**/*.less") unless theme
@@ -183,7 +183,7 @@ module.exports = (grunt) ->
   grunt.initConfig
     pkg: grunt.file.readJSON('package.json')
 
-    atom: {appDir, appName, symbolsDir, buildDir, contentsDir, installDir, shellAppDir}
+    nylas: {appDir, appName, symbolsDir, buildDir, contentsDir, installDir, shellAppDir}
 
     docsOutputDir: 'docs/output'
 
@@ -312,7 +312,7 @@ module.exports = (grunt) ->
         exe: 'nylas.exe'
 
     shell:
-      'kill-atom':
+      'kill-nylas':
         command: killCommand
         options:
           stdout: false
@@ -321,7 +321,7 @@ module.exports = (grunt) ->
 
   grunt.registerTask('compile', ['coffee', 'cjsx', 'prebuild-less', 'cson', 'peg'])
   grunt.registerTask('lint', ['coffeelint', 'csslint', 'lesslint', 'nylaslint'])
-  grunt.registerTask('test', ['shell:kill-atom', 'run-edgehill-specs'])
+  grunt.registerTask('test', ['shell:kill-nylas', 'run-edgehill-specs'])
   grunt.registerTask('docs', ['build-docs', 'render-docs'])
 
   ciTasks = ['output-disk-space', 'download-electron', 'build']

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -173,7 +173,7 @@ module.exports = (grunt) ->
       continue unless grunt.file.isFile(metadataPath)
 
       {engines, theme} = grunt.file.readJSON(metadataPath)
-      if engines?.nylas?
+      if engines?.atom?
         coffeeConfig.glob_to_multiple.src.push("#{directory}/**/*.coffee")
         lessConfig.glob_to_multiple.src.push("#{directory}/**/*.less")
         prebuildLessConfig.src.push("#{directory}/**/*.less") unless theme

--- a/build/tasks/build-task.coffee
+++ b/build/tasks/build-task.coffee
@@ -12,9 +12,9 @@ module.exports = (grunt) ->
       return ''
 
   grunt.registerTask 'build', 'Build the application', ->
-    shellAppDir = grunt.config.get('atom.shellAppDir')
-    buildDir = grunt.config.get('atom.buildDir')
-    appDir = grunt.config.get('atom.appDir')
+    shellAppDir = grunt.config.get('nylas.shellAppDir')
+    buildDir = grunt.config.get('nylas.buildDir')
+    appDir = grunt.config.get('nylas.appDir')
 
     rm shellAppDir
     rm path.join(buildDir, 'installer')

--- a/build/tasks/clean-task.coffee
+++ b/build/tasks/clean-task.coffee
@@ -7,7 +7,7 @@ module.exports = (grunt) ->
   grunt.registerTask 'partial-clean', 'Delete some of the build files', ->
     tmpdir = os.tmpdir()
 
-    rm grunt.config.get('atom.buildDir')
+    rm grunt.config.get('nylas.buildDir')
     rm require('../src/coffee-cache').cacheDir
     rm require('../src/less-compile-cache').cacheDir
     rm path.join(tmpdir, 'atom-cached-electrons')

--- a/build/tasks/codesign-task.coffee
+++ b/build/tasks/codesign-task.coffee
@@ -38,7 +38,7 @@ module.exports = (grunt) ->
     switch process.platform
       when 'darwin'
         cmd = 'codesign'
-        args = ['--deep', '--force', '--verbose', '--sign', 'Developer ID Application: InboxApp, Inc.', grunt.config.get('atom.shellAppDir')]
+        args = ['--deep', '--force', '--verbose', '--sign', 'Developer ID Application: InboxApp, Inc.', grunt.config.get('nylas.shellAppDir')]
         spawn {cmd, args}, (error) -> callback(error)
       when 'win32'
         # TODO: Don't do anything now, because we need a certificate pfx file
@@ -46,12 +46,12 @@ module.exports = (grunt) ->
         return callback()
         spawn {cmd: 'taskkill', args: ['/F', '/IM', 'nylas.exe']}, ->
           cmd = process.env.JANKY_SIGNTOOL ? 'signtool'
-          args = ['sign', path.join(grunt.config.get('atom.shellAppDir'), 'nylas.exe')]
+          args = ['sign', path.join(grunt.config.get('nylas.shellAppDir'), 'nylas.exe')]
 
           spawn {cmd, args}, (error) ->
             return callback(error) if error?
 
-            setupExePath = path.resolve(grunt.config.get('atom.buildDir'), 'installer', 'NylasSetup.exe')
+            setupExePath = path.resolve(grunt.config.get('nylas.buildDir'), 'installer', 'NylasSetup.exe')
             if fs.isFileSync(setupExePath)
               args = ['sign', setupExePath]
               spawn {cmd, args}, (error) -> callback(error)

--- a/build/tasks/compile-packages-slug-task.coffee
+++ b/build/tasks/compile-packages-slug-task.coffee
@@ -7,7 +7,7 @@ module.exports = (grunt) ->
   {spawn, rm} = require('./task-helpers')(grunt)
 
   grunt.registerTask 'compile-packages-slug', 'Add bundled package metadata information to the main package.json file', ->
-    appDir = fs.realpathSync(grunt.config.get('atom.appDir'))
+    appDir = fs.realpathSync(grunt.config.get('nylas.appDir'))
 
     modulesDirectory = path.join(appDir, 'node_modules')
     internalNylasPackagesDirectory = path.join(appDir, 'internal_packages')

--- a/build/tasks/copy-info-plist-task.coffee
+++ b/build/tasks/copy-info-plist-task.coffee
@@ -4,7 +4,7 @@ module.exports = (grunt) ->
   {cp} = require('./task-helpers')(grunt)
 
   grunt.registerTask 'copy-info-plist', 'Copy plist', ->
-    contentsDir = grunt.config.get('atom.contentsDir')
+    contentsDir = grunt.config.get('nylas.contentsDir')
     plistPath = path.join(contentsDir, 'Info.plist')
     helperPlistPath = path.join(contentsDir, 'Frameworks/Atom Helper.app/Contents/Info.plist')
 

--- a/build/tasks/dump-symbols-task.coffee
+++ b/build/tasks/dump-symbols-task.coffee
@@ -24,7 +24,7 @@ module.exports = (grunt) ->
   grunt.registerTask 'dump-symbols', 'Dump symbols for native modules', ->
     done = @async()
 
-    symbolsDir = grunt.config.get('atom.symbolsDir')
+    symbolsDir = grunt.config.get('nylas.symbolsDir')
     rm symbolsDir
     mkdir symbolsDir
 

--- a/build/tasks/generate-asar-task.coffee
+++ b/build/tasks/generate-asar-task.coffee
@@ -17,7 +17,7 @@ module.exports = (grunt) ->
     ]
     unpack = "{#{unpack.join(',')}}"
 
-    appDir = grunt.config.get('atom.appDir')
+    appDir = grunt.config.get('nylas.appDir')
     unless fs.existsSync(appDir)
       grunt.log.error 'The app has to be built before generating asar archive.'
       return done(false)

--- a/build/tasks/generate-license-task.coffee
+++ b/build/tasks/generate-license-task.coffee
@@ -17,7 +17,7 @@ module.exports = (grunt) ->
 
       licenseText = getLicenseText(dependencyLicenses)
       if mode is 'save'
-        targetPath = path.resolve(grunt.config.get('atom.appDir'), '..', 'LICENSE.md')
+        targetPath = path.resolve(grunt.config.get('nylas.appDir'), '..', 'LICENSE.md')
         fs.writeFileSync(targetPath, licenseText)
       else
         console.log licenseText

--- a/build/tasks/generate-module-cache-task.coffee
+++ b/build/tasks/generate-module-cache-task.coffee
@@ -4,7 +4,7 @@ ModuleCache = require '../../src/module-cache'
 
 module.exports = (grunt) ->
   grunt.registerTask 'generate-module-cache', 'Generate a module cache for all core modules and packages', ->
-    appDir = grunt.config.get('atom.appDir')
+    appDir = grunt.config.get('nylas.appDir')
 
     {packageDependencies} = grunt.file.readJSON('package.json')
 

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -8,8 +8,8 @@ module.exports = (grunt) ->
   {cp, mkdir, rm} = require('./task-helpers')(grunt)
 
   grunt.registerTask 'install', 'Install the built application', ->
-    installDir = grunt.config.get('atom.installDir')
-    shellAppDir = grunt.config.get('atom.shellAppDir')
+    installDir = grunt.config.get('nylas.installDir')
+    shellAppDir = grunt.config.get('nylas.shellAppDir')
 
     if process.platform is 'win32'
       runas ?= require 'runas'

--- a/build/tasks/mkdeb-task.coffee
+++ b/build/tasks/mkdeb-task.coffee
@@ -9,7 +9,7 @@ module.exports = (grunt) ->
     template = _.template(String(fs.readFileSync("#{filePath}.in")))
     filled = template(data)
 
-    outputPath = path.join(grunt.config.get('atom.buildDir'), path.basename(filePath))
+    outputPath = path.join(grunt.config.get('nylas.buildDir'), path.basename(filePath))
     grunt.file.write(outputPath, filled)
     outputPath
 
@@ -22,7 +22,7 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'mkdeb', 'Create debian package', ->
     done = @async()
-    buildDir = grunt.config.get('atom.buildDir')
+    buildDir = grunt.config.get('nylas.buildDir')
 
     if process.arch is 'ia32'
       arch = 'i386'

--- a/build/tasks/mkdmg-task.coffee
+++ b/build/tasks/mkdmg-task.coffee
@@ -6,11 +6,11 @@ Promise = require("bluebird")
 module.exports = (grunt) ->
   {spawn, rm} = require('./task-helpers')(grunt)
 
-  appName = -> grunt.config.get('atom.appName')
+  appName = -> grunt.config.get('nylas.appName')
   dmgName = -> "#{appName().split('.')[0]}.dmg"
-  buildDir = -> grunt.config.get('atom.buildDir')
+  buildDir = -> grunt.config.get('nylas.buildDir')
   dmgPath = -> path.join(buildDir(), dmgName())
-  appDir = -> path.join(buildDir(), grunt.config.get('atom.appName'))
+  appDir = -> path.join(buildDir(), grunt.config.get('nylas.appName'))
 
   getDmgExecutable = ->
     new Promise (resolve, reject) ->

--- a/build/tasks/mkrpm-task.coffee
+++ b/build/tasks/mkrpm-task.coffee
@@ -9,7 +9,7 @@ module.exports = (grunt) ->
     template = _.template(String(fs.readFileSync("#{filePath}.in")))
     filled = template(data)
 
-    outputPath = path.join(grunt.config.get('atom.buildDir'), path.basename(filePath))
+    outputPath = path.join(grunt.config.get('nylas.buildDir'), path.basename(filePath))
     grunt.file.write(outputPath, filled)
     outputPath
 
@@ -24,13 +24,13 @@ module.exports = (grunt) ->
       return done("Unsupported arch #{process.arch}")
 
     {name, version, description} = grunt.file.readJSON('package.json')
-    buildDir = grunt.config.get('atom.buildDir')
+    buildDir = grunt.config.get('nylas.buildDir')
 
     rpmDir = path.join(buildDir, 'rpm')
     rm rpmDir
     mkdir rpmDir
 
-    installDir = grunt.config.get('atom.installDir')
+    installDir = grunt.config.get('nylas.installDir')
     shareDir = path.join(installDir, 'share', 'nylas')
     iconName = path.join(shareDir, 'resources', 'app', 'resources', 'nylas.png')
 

--- a/build/tasks/output-build-filetypes.coffee
+++ b/build/tasks/output-build-filetypes.coffee
@@ -2,7 +2,7 @@ path = require 'path'
 
 module.exports = (grunt) ->
   grunt.registerTask 'output-build-filetypes', 'Log counts for each filetype in the built application', ->
-    shellAppDir = grunt.config.get('atom.shellAppDir')
+    shellAppDir = grunt.config.get('nylas.shellAppDir')
 
     types = {}
     grunt.file.recurse shellAppDir, (absolutePath, rootPath, relativePath, fileName) ->

--- a/build/tasks/output-long-paths-task.coffee
+++ b/build/tasks/output-long-paths-task.coffee
@@ -2,7 +2,7 @@ path = require 'path'
 
 module.exports = (grunt) ->
   grunt.registerTask 'output-long-paths', 'Log long paths in the built application', ->
-    shellAppDir = grunt.config.get('atom.shellAppDir')
+    shellAppDir = grunt.config.get('nylas.shellAppDir')
 
     longPaths = []
     grunt.file.recurse shellAppDir, (absolutePath, rootPath, relativePath, fileName) ->

--- a/build/tasks/prebuild-less-task.coffee
+++ b/build/tasks/prebuild-less-task.coffee
@@ -9,7 +9,7 @@ module.exports = (grunt) ->
       ['ui-light', 'ui-dark']
     ]
 
-    directory = path.join(grunt.config.get('atom.appDir'), 'less-compile-cache')
+    directory = path.join(grunt.config.get('nylas.appDir'), 'less-compile-cache')
 
     for configuration in prebuiltConfigurations
       importPaths = grunt.config.get('less.options.paths')

--- a/build/tasks/publish-nylas-build-task.coffee
+++ b/build/tasks/publish-nylas-build-task.coffee
@@ -12,7 +12,7 @@ fullVersion = null
 module.exports = (grunt) ->
   {cp, spawn, rm} = require('./task-helpers')(grunt)
 
-  appName = -> grunt.config.get('atom.appName')
+  appName = -> grunt.config.get('nylas.appName')
   dmgName = -> "#{appName().split('.')[0]}.dmg"
   zipName = -> "#{appName().split('.')[0]}.zip"
   winReleasesName = -> "RELEASES"
@@ -21,7 +21,7 @@ module.exports = (grunt) ->
 
   populateVersion = ->
     new Promise (resolve, reject) ->
-      json = require(path.join(grunt.config.get('atom.appDir'), 'package.json'))
+      json = require(path.join(grunt.config.get('nylas.appDir'), 'package.json'))
       cmd = 'git'
       args = ['rev-parse', '--short', 'HEAD']
       spawn {cmd, args}, (error, {stdout}={}, code) ->
@@ -37,7 +37,7 @@ module.exports = (grunt) ->
   runEmailIntegrationTest = ->
     return Promise.resolve() unless process.platform is 'darwin'
 
-    buildDir = grunt.config.get('atom.buildDir')
+    buildDir = grunt.config.get('nylas.buildDir')
     new Promise (resolve, reject) ->
       appToRun = path.join(buildDir, appName())
       scriptToRun = "./build/run-build-and-send-screenshot.scpt"
@@ -88,7 +88,7 @@ module.exports = (grunt) ->
         resolve(data)
 
   uploadToS3 = (filename, key) ->
-    buildDir = grunt.config.get('atom.buildDir')
+    buildDir = grunt.config.get('nylas.buildDir')
     filepath = path.join(buildDir, filename)
 
     grunt.log.writeln ">> Uploading #{filename} to #{key}…"
@@ -98,7 +98,7 @@ module.exports = (grunt) ->
         Promise.resolve(data)
 
   uploadZipToS3 = (filenameToZip, key) ->
-    buildDir = grunt.config.get('atom.buildDir')
+    buildDir = grunt.config.get('nylas.buildDir')
     buildZipFilename = "#{filenameToZip}.zip"
     buildZipPath = path.join(buildDir, buildZipFilename)
 

--- a/build/tasks/set-exe-icon-task.coffee
+++ b/build/tasks/set-exe-icon-task.coffee
@@ -4,7 +4,7 @@ module.exports = (grunt) ->
   grunt.registerTask 'set-exe-icon', 'Set icon of the exe', ->
     done = @async()
 
-    shellAppDir = grunt.config.get('atom.shellAppDir')
+    shellAppDir = grunt.config.get('nylas.shellAppDir')
     shellExePath = path.join(shellAppDir, 'nylas.exe')
     iconPath = path.resolve('build', 'resources', 'win', 'nylas.ico')
 

--- a/build/tasks/set-version-task.coffee
+++ b/build/tasks/set-version-task.coffee
@@ -8,7 +8,7 @@ module.exports = (grunt) ->
     onBuildMachine = process.env.JANKY_SHA1 and process.env.JANKY_BRANCH is 'master'
     onWindows = process.platform is 'win32'
     inRepository = fs.existsSync(path.resolve(__dirname, '..', '..', '.git'))
-    {version} = require(path.join(grunt.config.get('atom.appDir'), 'package.json'))
+    {version} = require(path.join(grunt.config.get('nylas.appDir'), 'package.json'))
     if onBuildMachine or onWindows or not inRepository
       callback(null, version)
     else
@@ -27,7 +27,7 @@ module.exports = (grunt) ->
         done(error)
         return
 
-      appDir = grunt.config.get('atom.appDir')
+      appDir = grunt.config.get('nylas.appDir')
 
       # Replace version field of package.json.
       packageJsonPath = path.join(appDir, 'package.json')
@@ -38,11 +38,11 @@ module.exports = (grunt) ->
 
       if process.platform is 'darwin'
         cmd = 'script/set-version'
-        args = [grunt.config.get('atom.buildDir'), version]
+        args = [grunt.config.get('nylas.buildDir'), version]
         spawn {cmd, args}, (error, result, code) -> done(error)
 
       else if process.platform is 'win32'
-        shellAppDir = grunt.config.get('atom.shellAppDir')
+        shellAppDir = grunt.config.get('nylas.shellAppDir')
         shellExePath = path.join(shellAppDir, 'nylas.exe')
 
         strings =

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -27,7 +27,7 @@ module.exports = (grunt) ->
     grunt.log.error(stderr)
 
   getAppPath = ->
-    contentsDir = grunt.config.get('atom.contentsDir')
+    contentsDir = grunt.config.get('nylas.contentsDir')
     switch process.platform
       when 'darwin'
         path.join(contentsDir, 'MacOS', 'Edgehill')
@@ -38,7 +38,7 @@ module.exports = (grunt) ->
 
   runPackageSpecs = (callback) ->
     failedPackages = []
-    rootDir = grunt.config.get('atom.shellAppDir')
+    rootDir = grunt.config.get('nylas.shellAppDir')
     resourcePath = process.cwd()
     appPath = getAppPath()
 

--- a/spec-saved-state.json
+++ b/spec-saved-state.json
@@ -1,0 +1,1 @@
+{"version":1,"windowDimensions":{"x":22,"y":45,"width":1000,"height":500,"maximized":false},"packageStates":{}}

--- a/src/global/nylas.coffee
+++ b/src/global/nylas.coffee
@@ -13,5 +13,5 @@ module.exports =
 
 # The following classes can't be used from a Task handler and should therefore
 # only be exported when not running as a child node process
-unless process.env.ATOM_SHELL_INTERNAL_RUN_AS_NODE
+unless process.env.NYLAS_INTERNAL_RUN_AS_NODE
   module.exports.Task = require '../task'

--- a/src/module-cache.coffee
+++ b/src/module-cache.coffee
@@ -196,8 +196,8 @@ resolveModulePath = (relativePath, parentModule) ->
 registerBuiltins = (devMode) ->
   if devMode or not cache.resourcePath.startsWith("#{process.resourcesPath}#{path.sep}")
     fs = require 'fs-plus'
-    atomCoffeePath = path.join(cache.resourcePath, 'src', 'global', 'atom.coffee')
-    cache.builtins.atom = atomCoffeePath if fs.isFileSync(atomCoffeePath)
+    nylasCoffeePath = path.join(cache.resourcePath, 'src', 'global', 'nylas.coffee')
+    cache.builtins.atom = nylasCoffeePath if fs.isFileSync(nylasCoffeePath)
   cache.builtins.atom ?= path.join(cache.resourcePath, 'src', 'global', 'atom.js')
 
   electronRoot = path.join(process.resourcesPath, 'atom.asar')

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -13,9 +13,9 @@ ThemePackage = require './theme-package'
 DatabaseStore = require './flux/stores/database-store'
 APMWrapper = require './apm-wrapper'
 
-# Extended: Package manager for coordinating the lifecycle of Atom packages.
+# Extended: Package manager for coordinating the lifecycle of Nylas packages.
 #
-# An instance of this class is always available as the `atom.packages` global.
+# An instance of this class is always available as the `nylas.packages` global.
 #
 # Packages can be loaded, activated, and deactivated, and unloaded:
 #  * Loading a package reads and parses the package's metadata and resources
@@ -29,7 +29,7 @@ APMWrapper = require './apm-wrapper'
 # Packages can be enabled/disabled via the `core.disabledPackages` config
 # settings and also by calling `enablePackage()/disablePackage()`.
 #
-# Section: Atom
+# Section: Nylas
 module.exports =
 class PackageManager
   EmitterMixin.includeInto(this)
@@ -175,7 +175,7 @@ class PackageManager
     packagePath = path.join(@resourcePath, 'node_modules', name)
     return packagePath if @hasAtomEngine(packagePath)
 
-  # Public: Is the package with the given name bundled with Atom?
+  # Public: Is the package with the given name bundled with Nylas?
   #
   # * `name` - The {String} package name.
   #
@@ -408,8 +408,8 @@ class PackageManager
   # windowType as `true` in their package.json file.
   loadPackages: (windowType) ->
     # Ensure src/global is already in the require cache so the load time
-    # of the first package isn't skewed by being the first to require atom
-    require './global/atom'
+    # of the first package isn't skewed by being the first to require nylas
+    require './global/nylas'
 
     packagePaths = @getAvailablePackagePaths(windowType)
 


### PR DESCRIPTION
The commits in relation to this pull request change the variable names from `atom` to `nylas` in the build scripts. I do not know if they should be `nylas` or `n1`.

Only commit 3a5e0f0 renames `atom.coffee` to `nylas.coffee`. I found the referenced files associated with the renamed file and altered them to point to the new file.

The name for a563f1d is not what the title says. I changed `engines?.atom?` to `engines?.nylas?`. That commit reverts that. Also, there were many other locations I would need to change and test if regressions occur.