### PR TITLE
Fixed a pixel cut in floating-toolbar

### DIFF
--- a/internal_packages/composer/stylesheets/composer.less
+++ b/internal_packages/composer/stylesheets/composer.less
@@ -384,7 +384,7 @@ body.platform-win32 {
     width: 22.5px;
     height: 10px;
     background: transparent url('images/tooltip/tooltip-bg-pointer@2x.png') no-repeat;
-    background-size: 22.5px 10.5px;
+    background-size: 22.5px 9.5px;
     margin-left: -11.2px;
   }
 


### PR DESCRIPTION
<img width="136" alt="screen shot 2015-10-22 at 11 20 09 am" src="https://cloud.githubusercontent.com/assets/538540/10657876/e98e4b2e-78ae-11e5-8cc7-ec5bb9bf5f7b.png">
