### PR TITLE
Update debian package libgcrypt dependency

### DIFF
--- a/build/resources/linux/debian/control.in
+++ b/build/resources/linux/debian/control.in
@@ -1,6 +1,6 @@
 Package: <%= name %>
 Version: <%= version %>
-Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils
+Depends: git, gconf2, gconf-service, libgtk2.0-0, libudev0 | libudev1, libgcrypt11 | libgcrypt20, libnotify4, libxtst6, libnss3, python, gvfs-bin, xdg-utils
 Suggests: libgnome-keyring0, gir1.2-gnomekeyring-1.0
 Section: <%= section %>
 Priority: optional


### PR DESCRIPTION
* Package libgcrypt11 is no longer available in Debian or Ubuntu
* Allow installing the package with libgcrypt20 instead

I was not able to install the Official .deb without this modification.

But after repacking the .deb with this change included, I was able to install and run N1 with no problems.

Debian Package Search:
https://packages.debian.org/search?keywords=libgcrypt&searchon=names&suite=stable&section=all

Ubuntu Package Search:
http://packages.ubuntu.com/search?keywords=libgcrypt&searchon=names&suite=wily&section=all
