### PR TITLE
Travis CI - Add support for Node 4.2 LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,14 @@ matrix:
       env: NODE_VERSION=0.10
     - os: linux
       env: NODE_VERSION=0.12
-    - os: linux
-      env: NODE_VERSION=4.1
+# Wants a c++11 compiler
+#    - os: linux
+#      env: NODE_VERSION=4.1
     - os: osx
       env: NODE_VERSION=0.10
-    - os: osx
-      env: NODE_VERSION=0.12
+# npn registry Connection Reset errors
+#    - os: osx
+#      env: NODE_VERSION=0.12
     - os: osx
       env: NODE_VERSION=4.1
 
@@ -26,6 +28,7 @@ install:
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION
   - nvm use --delete-prefix $NODE_VERSION
+  - clang --version
 
 script: script/cibuild
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ install:
   - git clone https://github.com/creationix/nvm.git /tmp/.nvm
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION
-  - [ "x$NODE_VERSION" == "x4.1" ] && npm config delete prefix
-  - nvm use $NODE_VERSION
+  - nvm use --delete-prefix $NODE_VERSION
 
 script: script/cibuild
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,17 @@ compiler:
 
 matrix:
   include:
-    - os: linux
-      env: NODE_VERSION=0.10
-    - os: linux
-      env: NODE_VERSION=0.12
 # Wants a c++11 compiler
+    - os: linux
+      env: NODE_VERSION=0.10 CC=gcc-4.8 CXX=g++-4.8
+    - os: linux
+      env: NODE_VERSION=0.12 CC=gcc-4.8 CXX=g++-4.8
     - os: linux
       env: NODE_VERSION=4.2 CC=gcc-4.8 CXX=g++-4.8
     - os: linux
       env: NODE_VERSION=5 CC=gcc-4.8 CXX=g++-4.8
     - os: osx
       env: NODE_VERSION=0.10
-# npn registry Connection Reset errors
     - os: osx
       env: NODE_VERSION=0.12 CC=clang CXX=clang++
 # osx already supports c++11 in Apple LLVM

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - echo $CC
   - echo $CXX
   - clang --version
+  - gcc -v
   - git clone https://github.com/creationix/nvm.git /tmp/.nvm
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
     - os: osx
       env: NODE_VERSION=0.10
 # npn registry Connection Reset errors
-#    - os: osx
-#      env: NODE_VERSION=0.12
+    - os: osx
+      env: NODE_VERSION=0.12 CC=clang CXX=clang++
 # osx already supports c++11 in Apple LLVM
     - os: osx
       env: NODE_VERSION=4.1 CC=clang CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,14 @@ matrix:
       env: NODE_VERSION=0.10
     - os: linux
       env: NODE_VERSION=0.12
+    - os: linux
+      env: NODE_VERSION=4.1
     - os: osx
       env: NODE_VERSION=0.10
     - os: osx
       env: NODE_VERSION=0.12
+    - os: osx
+      env: NODE_VERSION=4.1
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,15 @@ matrix:
       env: NODE_VERSION=0.12
 # Wants a c++11 compiler
     - os: linux
-      env: NODE_VERSION=4.1
+      env: NODE_VERSION=4.1 CC=gcc-4.8 CXX=g++-4.8
     - os: osx
       env: NODE_VERSION=0.10
 # npn registry Connection Reset errors
 #    - os: osx
 #      env: NODE_VERSION=0.12
+# osx already supports c++11 in Apple LLVM
     - os: osx
-      env: NODE_VERSION=4.1
+      env: NODE_VERSION=4.1 CC=clang CXX=clang++
 
 sudo: false
 
@@ -29,7 +30,6 @@ install:
   - echo $CC
   - echo $CXX
   - clang --version
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
   - git clone https://github.com/creationix/nvm.git /tmp/.nvm
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - echo $CC
   - echo $CXX
   - clang --version
-  - gcc -v
+  - if [ "$CC" = "gcc-4.8" ]; then gcc-4.8 -v; else gcc -v; fi
   - git clone https://github.com/creationix/nvm.git /tmp/.nvm
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ env:
   global:
     - NYLAS_ACCESS_TOKEN=cb200be7c921f73a1c35930f6a4ac8758b271be0
 
-compiler: clang
+compiler:
+  - clang
+  - gcc
 
 matrix:
   include:
@@ -11,8 +13,8 @@ matrix:
     - os: linux
       env: NODE_VERSION=0.12
 # Wants a c++11 compiler
-#    - os: linux
-#      env: NODE_VERSION=4.1
+    - os: linux
+      env: NODE_VERSION=4.1
     - os: osx
       env: NODE_VERSION=0.10
 # npn registry Connection Reset errors
@@ -24,6 +26,7 @@ matrix:
 sudo: false
 
 install:
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
   - git clone https://github.com/creationix/nvm.git /tmp/.nvm
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION
@@ -34,8 +37,12 @@ script: script/cibuild
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
     - build-essential
+    - clang
+    - fakeroot
+    - g++-4.8
     - git
     - libgnome-keyring-dev
-    - fakeroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,14 @@ matrix:
 sudo: false
 
 install:
+  - echo $CC
+  - echo $CXX
+  - clang --version
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
   - git clone https://github.com/creationix/nvm.git /tmp/.nvm
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION
   - nvm use --delete-prefix $NODE_VERSION
-  - clang --version
 
 script: script/cibuild
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ matrix:
       env: NODE_VERSION=0.12
 # Wants a c++11 compiler
     - os: linux
-      env: NODE_VERSION=4.1 CC=gcc-4.8 CXX=g++-4.8
+      env: NODE_VERSION=4.2 CC=gcc-4.8 CXX=g++-4.8
+    - os: linux
+      env: NODE_VERSION=5 CC=gcc-4.8 CXX=g++-4.8
     - os: osx
       env: NODE_VERSION=0.10
 # npn registry Connection Reset errors
@@ -22,7 +24,9 @@ matrix:
       env: NODE_VERSION=0.12 CC=clang CXX=clang++
 # osx already supports c++11 in Apple LLVM
     - os: osx
-      env: NODE_VERSION=4.1 CC=clang CXX=clang++
+      env: NODE_VERSION=4.2 CC=clang CXX=clang++
+    - os: osx
+      env: NODE_VERSION=5 CC=clang CXX=clang++
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - git clone https://github.com/creationix/nvm.git /tmp/.nvm
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION
+  - [ "x$NODE_VERSION" == "x4.1" ] && npm config delete prefix
   - nvm use $NODE_VERSION
 
 script: script/cibuild


### PR DESCRIPTION
This pull request adds support for node 4.2 for both Linux and OS X. The build environment for Linux at Travis uses Ubuntu 12.04 which includes GCC 4.6 that doesn't support C++11 extensions required by NAN for building under Node 4.2.

I added the `ubuntu-toolchain-r-test` repository to install a newer GCC 4.8 that can build Nylas N1 under Node 4.2.

For some strange reason, some builds on OS X under Node 0.12 fail during the NPM download stage with Connection Reset errors.

EDIT: Change 4.1 to 4.2. Node v4.2 is the LTS release. Node v5 is the latest/stable release.