### PR TITLE
Allows package to be installed in ElementaryOS

### DIFF
--- a/build/resources/linux/debian/postinst
+++ b/build/resources/linux/debian/postinst
@@ -24,7 +24,7 @@ case "$1" in
 
         DISTRO=`lsb_release -s -i`
 
-        if [ "$DISTRO" = "Ubuntu" ]; then
+        if [ "$DISTRO" = "Ubuntu" ] || [ "$DISTRO" = "elementary OS" ]; then
           DISTS=$UBUNTU_CODENAMES
           DISTRO="ubuntu"
         elif [ "$DISTRO" = "Debian" ]; then


### PR DESCRIPTION
Changes the condition for detecting the distro name so ElementaryOS (ubuntu based) goes as an Ubuntu and the package installs.