### PR TITLE
fix(FileDownloadStore): delete download from @_downloads after @trigger

### DIFF
--- a/src/flux/stores/file-download-store.coffee
+++ b/src/flux/stores/file-download-store.coffee
@@ -231,8 +231,8 @@ FileDownloadStore = Reflux.createStore
 
   _cleanupDownload: (download) ->
     download.abort()
-    delete @_downloads[download.fileId]
     @trigger()
+    delete @_downloads[download.fileId]
 
   _defaultSavePath: (file) ->
     if process.platform is 'win32'


### PR DESCRIPTION
From #412:

In src/flux/stores/FileDownloadStore.coffee, I noticed in _cleanupDownload on line 233-236 that you trigger the store update callbacks after deleting the fulfilled event.

This prevents me from using the event to detect when an attachment download finished in my PGP plugin. The events completed events are not present in the Object so I cannot detect the change.