### PR TITLE
Remove vm-compatibility-layer

### DIFF
--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -38,10 +38,6 @@ babelOptions = require '../static/babelrc'
 # binDir     = /usr/local/bin
 # shareDir   = /usr/local/share/nylas
 
-# Add support for obselete APIs of vm module so we can make some third-party
-# modules work under node v0.11.x.
-require 'vm-compatibility-layer'
-
 _ = require 'underscore'
 
 packageJson = require '../package.json'

--- a/build/package.json
+++ b/build/package.json
@@ -54,7 +54,6 @@
     "underscore": "^1.8",
     "underscore.string": "^3.2",
     "unzip": "~0.1.9",
-    "vm-compatibility-layer": "~0.1.0",
     "webdriverio": "^2.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "temp": "^0.8",
     "theorist": "^1.0",
     "underscore": "^1.8",
-    "underscore.string": "^3.0",
-    "vm-compatibility-layer": "0.1.0"
+    "underscore.string": "^3.0"
   },
   "packageDependencies": {},
   "private": true,


### PR DESCRIPTION
`vm-compatibility-layer` was designed to support obsolete APIs in node v0.11.x of node v0.10.x. It is only used in the build Gruntfile and nowhere else in the project.

I ran the build without `vm-compatibility-layer` and it completed with no errors, thus demonstrating its nonessential.

Atom already removed `vm-compatibility-layer` a few versions ago.