### PR TITLE
Do not return when original body is null

### DIFF
--- a/src/flux/stores/message-body-processor.coffee
+++ b/src/flux/stores/message-body-processor.coffee
@@ -1,3 +1,4 @@
+_ = require "underscore"
 crypto = require "crypto"
 MessageUtils = require '../models/message-utils'
 MessageStore = require './message-store'
@@ -38,6 +39,8 @@ class MessageBodyProcessor
 
   process: (message) =>
     body = message.body
+    return "" unless _.isString message.body
+
     key = @_key(message)
     if @_recentlyProcessedD[key]
       return @_recentlyProcessedD[key].body

--- a/src/flux/stores/message-body-processor.coffee
+++ b/src/flux/stores/message-body-processor.coffee
@@ -38,8 +38,6 @@ class MessageBodyProcessor
 
   process: (message) =>
     body = message.body
-    return "" unless body
-
     key = @_key(message)
     if @_recentlyProcessedD[key]
       return @_recentlyProcessedD[key].body


### PR DESCRIPTION
39a142ddcb80c7e1fce22dfe1e0e628272154523 fixed the prime issue of #436, but introduced another issue. Facebook emails have a `""` body initially. The return statement in the `process` method of `MessageBodyProcessor` causes the method to return early, ignoring my extension that would set the body at https://github.com/mbilker/email-pgp/blob/master/lib/message-loader/message-loader-extension.es6#L19. This PR removes the return statement, but leaves in the change in the hash key for caching messages.