### PR TITLE
Travis Linux Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,6 @@ matrix:
 
 sudo: false
 
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-
 install:
   - echo $CC
   - echo $CXX
@@ -42,6 +38,10 @@ install:
   - source /tmp/.nvm/nvm.sh
   - nvm install $NODE_VERSION
   - nvm use --delete-prefix $NODE_VERSION
+
+before_script:
+  - [ "${TRAVIS_OS_NAME}" == "linux" ] && export DISPLAY=:99.0
+  - [ "${TRAVIS_OS_NAME}" == "linux" ] && sh -e /etc/init.d/xvfb start
 
 script: script/cibuild
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
 
 sudo: false
 
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
 install:
   - echo $CC
   - echo $CXX
@@ -52,3 +56,4 @@ addons:
     - g++-4.8
     - git
     - libgnome-keyring-dev
+    - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ matrix:
   include:
 # Wants a c++11 compiler
     - os: linux
-      env: NODE_VERSION=0.10 CC=gcc-4.8 CXX=g++-4.8
+      env: NODE_VERSION=0.10 CC=gcc-4.8 CXX=g++-4.8 NYLAS_HOME=/home/travis/.nylas
     - os: linux
-      env: NODE_VERSION=0.12 CC=gcc-4.8 CXX=g++-4.8
+      env: NODE_VERSION=0.12 CC=gcc-4.8 CXX=g++-4.8 NYLAS_HOME=/home/travis/.nylas
     - os: linux
-      env: NODE_VERSION=4.2 CC=gcc-4.8 CXX=g++-4.8
+      env: NODE_VERSION=4.2 CC=gcc-4.8 CXX=g++-4.8 NYLAS_HOME=/home/travis/.nylas
     - os: linux
-      env: NODE_VERSION=5 CC=gcc-4.8 CXX=g++-4.8
+      env: NODE_VERSION=5 CC=gcc-4.8 CXX=g++-4.8 NYLAS_HOME=/home/travis/.nylas
     - os: osx
       env: NODE_VERSION=0.10
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,10 @@ install:
   - nvm use --delete-prefix $NODE_VERSION
 
 before_script:
-  - [ "${TRAVIS_OS_NAME}" == "linux" ] && export DISPLAY=:99.0
-  - [ "${TRAVIS_OS_NAME}" == "linux" ] && sh -e /etc/init.d/xvfb start
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+    export DISPLAY=:99.0;
+    sh -e /etc/init.d/xvfb start;
+    fi
 
 script: script/cibuild
 

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -362,7 +362,7 @@ module.exports = (grunt) ->
   ciTasks = ['output-disk-space', 'download-electron', 'build']
   ciTasks.push('dump-symbols') if process.platform isnt 'win32'
   ciTasks.push('set-version', 'lint', 'generate-asar')
-  ciTasks.push('test') if process.platform is 'darwin'
+  ciTasks.push('test') if process.platform isnt 'win32'
 
   unless process.env.TRAVIS
     ciTasks.push('codesign')

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -42,9 +42,9 @@ module.exports = (grunt) ->
     done = @async()
     npmPath = path.resolve "./build/node_modules/.bin/npm"
 
-    #if process.platform isnt 'darwin'
-    #  grunt.log.error("run-spectron-specs only works on Mac OS X at the moment.")
-    #  done(false)
+    if process.platform is 'win32'
+      grunt.log.error("run-spectron-specs only works on Mac OS X at the moment.")
+      done(false)
 
     if not fs.existsSync(executablePath)
       grunt.log.error("run-spectron-specs requires the built version of the app at #{executablePath}")

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -34,7 +34,7 @@ module.exports = (grunt) ->
   grunt.registerTask 'run-spectron-specs', 'Run spectron specs', ->
     shellAppDir = grunt.config.get('nylasGruntConfig.shellAppDir')
 
-    if process.platform is 'darwine'
+    if process.platform is 'darwin'
       executablePath = path.join(shellAppDir, 'Contents', 'MacOS', 'Nylas')
     else
       executablePath = path.join(shellAppDir, 'nylas')

--- a/build/tasks/spec-task.coffee
+++ b/build/tasks/spec-task.coffee
@@ -33,14 +33,18 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'run-spectron-specs', 'Run spectron specs', ->
     shellAppDir = grunt.config.get('nylasGruntConfig.shellAppDir')
-    executablePath = path.join(shellAppDir, 'Contents', 'MacOS', 'Nylas')
+
+    if process.platform is 'darwine'
+      executablePath = path.join(shellAppDir, 'Contents', 'MacOS', 'Nylas')
+    else
+      executablePath = path.join(shellAppDir, 'nylas')
 
     done = @async()
     npmPath = path.resolve "./build/node_modules/.bin/npm"
 
-    if process.platform isnt 'darwin'
-      grunt.log.error("run-spectron-specs only works on Mac OS X at the moment.")
-      done(false)
+    #if process.platform isnt 'darwin'
+    #  grunt.log.error("run-spectron-specs only works on Mac OS X at the moment.")
+    #  done(false)
 
     if not fs.existsSync(executablePath)
       grunt.log.error("run-spectron-specs requires the built version of the app at #{executablePath}")

--- a/internal_packages/composer/spec/composer-view-spec.cjsx
+++ b/internal_packages/composer/spec/composer-view-spec.cjsx
@@ -538,7 +538,11 @@ describe "populated composer", ->
         @$composer = @composer.refs.composerWrap
 
       it "sends the draft on cmd-enter", ->
-        NylasTestUtils.keyPress("cmd-enter", React.findDOMNode(@$composer))
+        if process.platform is "darwin"
+          cmdctrl = 'cmd'
+        else
+          cmdctrl = 'ctrl'
+        NylasTestUtils.keyPress("#{cmdctrl}-enter", React.findDOMNode(@$composer))
         expect(Actions.sendDraft).toHaveBeenCalled()
         expect(Actions.sendDraft.calls.length).toBe 1
 
@@ -547,12 +551,16 @@ describe "populated composer", ->
         expect(Actions.sendDraft).not.toHaveBeenCalled()
 
       it "doesn't let you send twice", ->
-        NylasTestUtils.keyPress("cmd-enter", React.findDOMNode(@$composer))
+        if process.platform is "darwin"
+          cmdctrl = 'cmd'
+        else
+          cmdctrl = 'ctrl'
+        NylasTestUtils.keyPress("#{cmdctrl}-enter", React.findDOMNode(@$composer))
         expect(Actions.sendDraft).toHaveBeenCalled()
         expect(Actions.sendDraft.calls.length).toBe 1
         @isSending = true
         DraftStore.trigger()
-        NylasTestUtils.keyPress("cmd-enter", React.findDOMNode(@$composer))
+        NylasTestUtils.keyPress("#{cmdctrl}-enter", React.findDOMNode(@$composer))
         expect(Actions.sendDraft).toHaveBeenCalled()
         expect(Actions.sendDraft.calls.length).toBe 1
 


### PR DESCRIPTION
This PR adds support for running the N1 Spec Suite under Linux. I only used the `master` branch of nylas/N1 for the testing. I haven't tested the `spectron` branch that is actively developing. There were some minor modifications made to the spec files to make the tests pass. `Xvfb` is installed in Travis and started only on Linux (doesn't exist on OS X clients) to provide a X11 window so the spec test doesn't complain there is no `DISPLAY` defined or available.

The keybinds differ between Mac OS X, Linux, and Windows. I added a wrapper for `cmdctrl` into each spec where the `cmd` keyboard modified was used (currently only found in `internal_packages/composer/spec/composer-view-spec.cjsx`). 