### PR TITLE
Removing deprecated 'activate-with-no-open-windows' event

### DIFF
--- a/src/browser/application.coffee
+++ b/src/browser/application.coffee
@@ -341,8 +341,9 @@ class Application
       # win = BrowserWindow.fromWebContents(event.sender)
       event.sender.send('inline-styles-result', {body, clientId})
 
-    app.on 'activate-with-no-open-windows', (event) =>
-      @openWindowsForTokenState()
+    app.on 'activate', (event, hasVisibleWindows) =>
+      if not hasVisibleWindows
+        @openWindowsForTokenState()
       event.preventDefault()
 
     ipcMain.on 'update-application-menu', (event, template, keystrokesByCommand) =>


### PR DESCRIPTION
Fixing #481

As mentioned on this Electron's issue: https://github.com/atom/electron/pull/2777

The `activate-with-open-windows` event has been deprecated in favor of a global `activate` event with a `hasVisibleWindows` parameter.

This prevents N1 from crashing when closing the main window and opening via clicking the Dock icon.