### PR TITLE
Convert Atom's launch script for N1

### DIFF
--- a/N1.sh
+++ b/N1.sh
@@ -3,14 +3,11 @@
 N1_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd );
 
 if [ "$(uname)" == 'Darwin' ]; then
-  OS='Mac'
   ELECTRON_PATH=${ELECTRON_PATH:-$N1_PATH/electron/Electron.app/Contents/MacOS/Electron}
 elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
-  OS='Linux'
   ELECTRON_PATH=${ELECTRON_PATH:-$N1_PATH/electron/electron}
   mkdir -p "$HOME/.nylas"
 elif [ "$(expr substr $(uname -s) 1 10)" == 'MINGW32_NT' ]; then
-  OS='Cygwin'
   ELECTRON_PATH=${ELECTRON_PATH:-$N1_PATH/electron/electron.exe}
 else
   echo "Your platform ($(uname -a)) is not supported."

--- a/build/Gruntfile.coffee
+++ b/build/Gruntfile.coffee
@@ -22,11 +22,11 @@ babelOptions = require '../static/babelrc'
 # tmpDir: /var/folders/xl/_qdlmc512sb6cpqryy_2tzzw0000gn/T/ (aka /tmp)
 #
 # buildDir    = /tmp/nylas-build
-# shellAppDir = /tmp/nylas-build/Nylas.app
-# contentsDir = /tmp/nylas-build/Nylas.app/Contents
-# appDir      = /tmp/nylas-build/Nylas.app/Contents/Resources/app
+# shellAppDir = /tmp/nylas-build/Nylas N1.app
+# contentsDir = /tmp/nylas-build/Nylas N1.app/Contents
+# appDir      = /tmp/nylas-build/Nylas N1.app/Contents/Resources/app
 #
-# installDir = /Applications/Nylas.app
+# installDir = /Applications/Nylas N1.app
 #
 # And on Linux:
 #
@@ -79,7 +79,7 @@ module.exports = (grunt) ->
   home = if process.platform is 'win32' then process.env.USERPROFILE else process.env.HOME
   electronDownloadDir = path.join(home, '.nylas', 'electron')
 
-  symbolsDir = path.join(buildDir, 'Atom.breakpad.syms')
+  symbolsDir = path.join(buildDir, 'Nylas.breakpad.syms')
   shellAppDir = path.join(buildDir, appName)
   if process.platform is 'win32'
     contentsDir = shellAppDir

--- a/build/resources/nylas.sh
+++ b/build/resources/nylas.sh
@@ -11,12 +11,6 @@ else
   exit 1
 fi
 
-if [ "$(basename $0)" == 'nylas-beta' ]; then
-  BETA_VERSION=true
-else
-  BETA_VERSION=
-fi
-
 while getopts ":wtfvh-:" opt; do
   case "$opt" in
     -)
@@ -55,11 +49,7 @@ if [ $EXPECT_OUTPUT ]; then
 fi
 
 if [ $OS == 'Mac' ]; then
-  if [ -n "$BETA_VERSION" ]; then
-    NYLAS_APP_NAME="Nylas N1 Beta.app"
-  else
-    NYLAS_APP_NAME="Nylas N1.app"
-  fi
+  NYLAS_APP_NAME="Nylas N1.app"
 
   if [ -z "${NYLAS_PATH}" ]; then
     # If NYLAS_PATH isnt set, check /Applications and then ~/Applications for Nylas N1.app
@@ -89,12 +79,7 @@ elif [ $OS == 'Linux' ]; then
   SCRIPT=$(readlink -f "$0")
   USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
 
-  if [ -n "$BETA_VERSION" ]; then
-    NYLAS_PATH="$USR_DIRECTORY/share/nylas-beta/nylas"
-  else
-    NYLAS_PATH="$USR_DIRECTORY/share/nylas/nylas"
-  fi
-
+  NYLAS_PATH="$USR_DIRECTORY/share/nylas/nylas"
   NYLAS_HOME="${NYLAS_HOME:-$HOME/.nylas}"
   mkdir -p "$NYLAS_HOME"
 

--- a/build/resources/nylas.sh
+++ b/build/resources/nylas.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+if [ "$(uname)" == 'Darwin' ]; then
+  OS='Mac'
+elif [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
+  OS='Linux'
+elif [ "$(expr substr $(uname -s) 1 10)" == 'MINGW32_NT' ]; then
+  OS='Cygwin'
+else
+  echo "Your platform ($(uname -a)) is not supported."
+  exit 1
+fi
+
+if [ "$(basename $0)" == 'nylas-beta' ]; then
+  BETA_VERSION=true
+else
+  BETA_VERSION=
+fi
+
+while getopts ":wtfvh-:" opt; do
+  case "$opt" in
+    -)
+      case "${OPTARG}" in
+        wait)
+          WAIT=1
+          ;;
+        help|version)
+          REDIRECT_STDERR=1
+          EXPECT_OUTPUT=1
+          ;;
+        foreground|test)
+          EXPECT_OUTPUT=1
+          ;;
+      esac
+      ;;
+    w)
+      WAIT=1
+      ;;
+    h|v)
+      REDIRECT_STDERR=1
+      EXPECT_OUTPUT=1
+      ;;
+    f|t)
+      EXPECT_OUTPUT=1
+      ;;
+  esac
+done
+
+if [ $REDIRECT_STDERR ]; then
+  exec 2> /dev/null
+fi
+
+if [ $EXPECT_OUTPUT ]; then
+  export ELECTRON_ENABLE_LOGGING=1
+fi
+
+if [ $OS == 'Mac' ]; then
+  if [ -n "$BETA_VERSION" ]; then
+    NYLAS_APP_NAME="Nylas N1 Beta.app"
+  else
+    NYLAS_APP_NAME="Nylas N1.app"
+  fi
+
+  if [ -z "${NYLAS_PATH}" ]; then
+    # If NYLAS_PATH isnt set, check /Applications and then ~/Applications for Nylas N1.app
+    if [ -x "/Applications/$NYLAS_APP_NAME" ]; then
+      NYLAS_PATH="/Applications"
+    elif [ -x "$HOME/Applications/$NYLAS_APP_NAME" ]; then
+      NYLAS_PATH="$HOME/Applications"
+    else
+      # We havent found an Nylas N1.app, use spotlight to search for N1
+      NYLAS_PATH="$(mdfind "kMDItemCFBundleIdentifier == 'com.nylas.nylas-mail'" | grep -v ShipIt | head -1 | xargs -0 dirname)"
+
+      # Exit if N1 can't be found
+      if [ ! -x "$NYLAS_PATH/$NYLAS_APP_NAME" ]; then
+        echo "Cannot locate 'Nylas N1.app', it is usually located in /Applications. Set the NYLAS_PATH environment variable to the directory containing 'Nylas N1.app'."
+        exit 1
+      fi
+    fi
+  fi
+
+  if [ $EXPECT_OUTPUT ]; then
+    "$NYLAS_PATH/$NYLAS_APP_NAME/Contents/MacOS/Nylas" --executed-from="$(pwd)" --pid=$$ "$@"
+    exit $?
+  else
+    open -a "$NYLAS_PATH/$NYLAS_APP_NAME" -n --args --executed-from="$(pwd)" --pid=$$ --path-environment="$PATH" "$@"
+  fi
+elif [ $OS == 'Linux' ]; then
+  SCRIPT=$(readlink -f "$0")
+  USR_DIRECTORY=$(readlink -f $(dirname $SCRIPT)/..)
+
+  if [ -n "$BETA_VERSION" ]; then
+    NYLAS_PATH="$USR_DIRECTORY/share/nylas-beta/nylas"
+  else
+    NYLAS_PATH="$USR_DIRECTORY/share/nylas/nylas"
+  fi
+
+  NYLAS_HOME="${NYLAS_HOME:-$HOME/.nylas}"
+  mkdir -p "$NYLAS_HOME"
+
+  : ${TMPDIR:=/tmp}
+
+  [ -x "$NYLAS_PATH" ] || NYLAS_PATH="$TMPDIR/nylas-build/Nylas/nylas"
+
+  if [ $EXPECT_OUTPUT ]; then
+    "$NYLAS_PATH" --executed-from="$(pwd)" --pid=$$ "$@"
+    exit $?
+  else
+    (
+    nohup "$NYLAS_PATH" --executed-from="$(pwd)" --pid=$$ "$@" > "$NYLAS_HOME/nohup.out" 2>&1
+    if [ $? -ne 0 ]; then
+      cat "$NYLAS_HOME/nohup.out"
+      exit $?
+    fi
+    ) &
+  fi
+fi
+
+# Exits this process when N1 exits
+on_die() {
+  exit 0
+}
+trap 'on_die' SIGQUIT SIGTERM
+
+# If the wait flag is set, don't exit this process until N1 tells it to.
+if [ $WAIT ]; then
+  while true; do
+    sleep 1
+  done
+fi

--- a/build/tasks/copy-files-for-build-task.coffee
+++ b/build/tasks/copy-files-for-build-task.coffee
@@ -49,7 +49,7 @@ module.exports = (grunt) ->
     mkdir appDir
 
     if process.platform isnt 'win32'
-      cp 'N1.sh', path.resolve(appDir, '..', 'new-app', 'N1.sh')
+      cp path.resolve('build', 'resources', 'nylas.sh'), path.resolve(appDir, '..', 'new-app', 'N1.sh')
 
     cp 'package.json', path.join(appDir, 'package.json')
     cp path.join('build', 'resources', 'nylas.png'), path.join(appDir, 'nylas.png')

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -37,9 +37,7 @@ module.exports = (grunt) ->
       iconName = path.join(linuxShareDir, 'resources', 'app', 'nylas.png')
 
       mkdir linuxBinDir
-      # Note that `N1.sh` can't be renamed `nylas.sh` because `apm`
-      # is currently hard-coded to call `N1.sh`
-      cp 'N1.sh', path.join(linuxBinDir, 'nylas')
+      cp path.join('build', 'resources', 'nylas.sh'), path.join(linuxBinDir, 'nylas')
       rm linuxShareDir
       mkdir path.dirname(linuxShareDir)
       cp shellAppDir, linuxShareDir


### PR DESCRIPTION
Addresses #411

The `N1.sh` launch script fails to account for running from `/usr/bin/nylas` or `/usr/local/bin/nylas` or `/opt/N1/bin/nylas` where it would throw an error saying it couldn't find the electron binary.

The Atom launch script works just fine and takes that into account. The installed launch script here is a refactored Atom launch script that properly accounts for running the `nylas` executable and locates the actual binary accordingly.