### PR TITLE
Replace function accessor with property accessor in Grunt's task-helper script

### DIFF
--- a/build/tasks/task-helpers.coffee
+++ b/build/tasks/task-helpers.coffee
@@ -77,9 +77,9 @@ module.exports = (grunt) ->
       false
 
   notifyAPI: (msg, callback) ->
-    if (process.env("NYLAS_INTERNAL_HOOK_URL") ? "").length > 0
+    if (process.env.NYLAS_INTERNAL_HOOK_URL ? "").length > 0
       request.post
-        url: process.env("NYLAS_INTERNAL_HOOK_URL")
+        url: process.env.NYLAS_INTERNAL_HOOK_URL
         json:
           username: "Edgehill Builds"
           text: msg


### PR DESCRIPTION
This bug appeared during a Travis test run, and only appeared on the Linux hosts running the tests. The function appears to treat the `process.env` as a set of functions, not properties.

This commit correctly interprets them as properties.

The main N1 repository no longer runs unit tests on Linux hosts, which is why this hasn't appeared during Travis builds, while my fork runs the unit tests on Linux under the Travis Ubuntu Trusty beta.