### PR TITLE
Require `classNames` throws error under Linux

### DIFF
--- a/src/components/editable-list.jsx
+++ b/src/components/editable-list.jsx
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import classNames from 'classNames';
+import classNames from 'classnames';
 import React, {Component, PropTypes} from 'react';
 
 class EditableList extends Component {


### PR DESCRIPTION
The issue stems that Mac OS X uses a case-insensitive filesystem by default, while most Linux filesystems are case-sensitive. The classNames package will require successfully on Mac OS X during Travis tests, but since the spec test suite isn't normally run under Linux this bug is more unlikely to appear.

This PR changes the module name to `classnames` instead of `classNames` to account for case-sensitive filesystems.