### PR TITLE
Fix broken icon from issue #465 and Fix icon path for install

### DIFF
--- a/build/resources/linux/nylas.desktop.in
+++ b/build/resources/linux/nylas.desktop.in
@@ -6,5 +6,6 @@ Exec=<%= installDir %>/share/nylas/nylas %U
 Icon=<%= iconName %>
 Type=Application
 StartupNotify=true
+StartupWMClass=Nylas N1
 Categories=GNOME;GTK;Utility;EmailClient;Development;
 MimeType=text/plain;x-scheme-handler/mailto;x-scheme-handler/nylas;

--- a/build/tasks/install-task.coffee
+++ b/build/tasks/install-task.coffee
@@ -33,7 +33,7 @@ module.exports = (grunt) ->
     else
       binDir = path.join(installDir, 'bin')
       shareDir = path.join(installDir, 'share', 'nylas')
-      iconName = path.join(shareDir, 'resources', 'app', 'resources', 'nylas.png')
+      iconName = path.join(shareDir, 'resources', 'app', 'nylas.png')
 
       mkdir binDir
       # Note that `N1.sh` can't be renamed `nylas.sh` because `apm`
@@ -50,7 +50,7 @@ module.exports = (grunt) ->
         desktopInstallFile = path.join(installDir, 'share', 'applications', 'nylas.desktop')
 
         {description} = grunt.file.readJSON('package.json')
-        iconName = path.join(shareDir, 'resources', 'app', 'resources', 'nylas.png')
+        iconName = path.join(shareDir, 'resources', 'app', 'nylas.png')
         installDir = path.join(installDir, '.') # To prevent "Exec=/usr/local//share/nylas/nylas"
         template = _.template(String(fs.readFileSync(desktopFile)))
         filled = template({description, installDir, iconName})


### PR DESCRIPTION
EDIT: I forgot to mention this is with Linux and GNOME specifically.

Issue #465 mentions a missing icon.  This should fix that by using the application name for StartupWMClass in the resulting .desktop file.  I had this problem and this fixed it.

Issue #242 mentions a bad path for the icon in the .desktop file.  It was caused by having an extra parameter which then made the Icon invalid.  I had this same issue and this fixed it.