### PR TITLE
Display the folders name with a slash.

### DIFF
--- a/internal_packages/category-picker/lib/category-picker.cjsx
+++ b/internal_packages/category-picker/lib/category-picker.cjsx
@@ -176,7 +176,7 @@ class CategoryPicker extends React.Component
     <RetinaImg name={"#{item.name}.png"} fallback={'folder.png'} mode={RetinaImg.Mode.ContentIsMask} />
 
   _renderBoldedSearchResults: (item) ->
-    name = item.display_name
+    name = @_toHumanName(item.display_name)
     searchTerm = (@state.searchValue ? "").trim()
 
     return name if searchTerm.length is 0
@@ -287,8 +287,11 @@ class CategoryPicker extends React.Component
       categoryUsageCount[category.id] += 1
     return categoryUsageCount
 
-  _isInSearch: (searchValue, category) ->
-    return Utils.wordSearchRegExp(searchValue).test(category.displayName)
+  _isInSearch: (searchValue, category) =>
+    return Utils.wordSearchRegExp(searchValue).test(@_toHumanName(category.displayName))
+
+  _toHumanName: (displayName) ->
+    return displayName.replace(/[./\\]/g, '/') if displayName?
 
   _isUserFacing: (allInInbox, category) =>
     hiddenCategories = []


### PR DESCRIPTION
When using imap folders, we don't want to display the sub folder separator like the point.

For *Archives.2008* it now display *Archives/2008*. It's also works when searching :mag: 

I copy/pasted the replace function from the [AccountSidebarStore](https://github.com/nylas/N1/blob/master/internal_packages/account-sidebar/lib/account-sidebar-store.coffee#L66). Do you know a place where we can reuse it?