### PR TITLE
Names with @ are included in the contact name.

### DIFF
--- a/spec/models/contact-spec.coffee
+++ b/spec/models/contact-spec.coffee
@@ -85,6 +85,45 @@ describe "Contact", ->
     expect(c3.displayFirstName()).toBe ""
     expect(c3.displayLastName()).toBe ""
 
+
+  it "properly parses names with @", ->
+    c1 = new Contact {name: "nyl@s"}
+    expect(c1.firstName()).toBe "Nyl@s"
+    expect(c1.lastName()).toBe ""
+
+    c1 = new Contact {name: "nyl@s@n1"}
+    expect(c1.firstName()).toBe "Nyl@s@n1"
+    expect(c1.lastName()).toBe ""
+
+    c2 = new Contact {name: "nyl@s nyl@s"}
+    expect(c2.firstName()).toBe "Nyl@s"
+    expect(c2.lastName()).toBe "Nyl@s"
+
+    c3 = new Contact {name: "nyl@s 2000"}
+    expect(c3.firstName()).toBe "Nyl@s"
+    expect(c3.lastName()).toBe "2000"
+
+    c4 = new Contact {name: " Ev@n Morikawa ", email: "evan@nylas.com"}
+    expect(c4.displayName()).toBe "Ev@n Morikawa"
+    expect(c4.displayFirstName()).toBe "Ev@n"
+    expect(c4.displayLastName()).toBe "Morikawa"
+
+    c5 = new Contact {name: "ev@n (Evan Morik@wa)"}
+    expect(c5.firstName()).toBe "Evan"
+    expect(c5.lastName()).toBe "Morik@wa"
+
+    c6 = new Contact {name: "ev@nylas.com", email: "ev@nylas.com"}
+    expect(c6.firstName()).toBe "Ev@nylas.com"
+    expect(c6.lastName()).toBe ""
+
+    c7 = new Contact {name: "evan@nylas.com"}
+    expect(c7.firstName()).toBe "Evan@nylas.com"
+    expect(c7.lastName()).toBe ""
+
+    c8 = new Contact {name: "Mike K@ylor via L@nkedIn"}
+    expect(c8.firstName()).toBe "Mike"
+    expect(c8.lastName()).toBe "K@ylor"
+
   it "should properly return `You` as the display name for the current user", ->
     c1 = new Contact {name: " Test Monkey", email: AccountStore.current().emailAddress}
     expect(c1.displayName()).toBe "You"

--- a/src/flux/models/contact.coffee
+++ b/src/flux/models/contact.coffee
@@ -130,7 +130,12 @@ class Contact extends Model
     name = @name
 
     # At this point, if the name is empty we'll use the email address
-    name = (@email || "") unless name && name.length
+    unless name && name.length
+      name = (@email || "")
+
+      # If the phrase has an '@', use everything before the @ sign
+      # Unless there that would result in an empty string.
+      name = name.split('@')[0] if name.indexOf('@') > 0
 
     # Take care of phrases like "evan (Evan Morikawa)" that should be displayed
     # as the contents of the parenthesis
@@ -139,10 +144,6 @@ class Contact extends Model
     # Take care of phrases like "Mike Kaylor via LinkedIn" that should be displayed
     # as the contents before the separator word. Do not break "Olivia"
     name = name.split(/(\svia\s)/i)[0]
-
-    # If the phrase has an '@', use everything before the @ sign
-    # Unless that would result in an empty string!
-    name = name.split('@')[0] if name.indexOf('@') > 0
 
     # Take care of whitespace
     name = name.trim()


### PR DESCRIPTION
This resolves #713. 

Tests have been added for this case but this change would parse a contact with the name "ev@nylas.com" to have a firstName of "Ev@nylas.com"

Previously this would have parsed to a firstName of "Ev". 

The only way around this is to introduce a email format check against names. I'm not sure how common it is to have a name field be a valid email address - but it might be more common than normal names that contain `@`. 
