### PR TITLE
AppVeyor Use no secure variables in Pull Requests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,18 +28,18 @@ install:
 
 # We need to extract the encrypted private ssh key to clone the submodule.
 - ps: |
-  if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
-    secure-file\tools\secure-file -decrypt build\resources\ssh\nylas-n1-ci-ssh-secure-file.enc -secret $env:DECRYPTION_PASSWORD
-    mv -Force build\resources\ssh\nylas-n1-ci-ssh-secure-file c:\users\appveyor\.ssh\id_rsa
-    git submodule init
+    if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+      secure-file\tools\secure-file -decrypt build\resources\ssh\nylas-n1-ci-ssh-secure-file.enc -secret $env:DECRYPTION_PASSWORD
+      mv -Force build\resources\ssh\nylas-n1-ci-ssh-secure-file c:\users\appveyor\.ssh\id_rsa
+      git submodule init
 
-    # http://stackoverflow.com/questions/21002919/running-a-remote-powershell-script-with-a-git-command-in-it-results-in-nativecom
-    Start-Process -FilePath git.exe -ArgumentList 'submodule update'  -Wait -NoNewWindow
+      # http://stackoverflow.com/questions/21002919/running-a-remote-powershell-script-with-a-git-command-in-it-results-in-nativecom
+      Start-Process -FilePath git.exe -ArgumentList 'submodule update'  -Wait -NoNewWindow
 
-    secure-file\tools\secure-file -decrypt build\resources\nylas\encrypted_certificates\appveyor\win-nylas-n1.p12.enc -secret $env:DECRYPTION_PASSWORD
-    secure-file\tools\secure-file -decrypt build\resources\nylas\encrypted_certificates\appveyor\set_win_env.ps1.enc -secret $env:DECRYPTION_PASSWORD
-    . build\resources\nylas\encrypted_certificates\appveyor\set_win_env.ps1
-  }
+      secure-file\tools\secure-file -decrypt build\resources\nylas\encrypted_certificates\appveyor\win-nylas-n1.p12.enc -secret $env:DECRYPTION_PASSWORD
+      secure-file\tools\secure-file -decrypt build\resources\nylas\encrypted_certificates\appveyor\set_win_env.ps1.enc -secret $env:DECRYPTION_PASSWORD
+      . build\resources\nylas\encrypted_certificates\appveyor\set_win_env.ps1
+    }
 
 build_script:
 - ps: .\script\cibuild.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,15 +27,19 @@ install:
 - ps: nuget install secure-file -ExcludeVersion
 
 # We need to extract the encrypted private ssh key to clone the submodule.
-- ps: secure-file\tools\secure-file -decrypt build\resources\ssh\nylas-n1-ci-ssh-secure-file.enc -secret $env:DECRYPTION_PASSWORD
-- ps: mv -Force build\resources\ssh\nylas-n1-ci-ssh-secure-file c:\users\appveyor\.ssh\id_rsa
-- ps: git submodule init
-# http://stackoverflow.com/questions/21002919/running-a-remote-powershell-script-with-a-git-command-in-it-results-in-nativecom
-- ps: Start-Process -FilePath git.exe -ArgumentList 'submodule update'  -Wait -NoNewWindow
+- ps: |
+  if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+    secure-file\tools\secure-file -decrypt build\resources\ssh\nylas-n1-ci-ssh-secure-file.enc -secret $env:DECRYPTION_PASSWORD
+    mv -Force build\resources\ssh\nylas-n1-ci-ssh-secure-file c:\users\appveyor\.ssh\id_rsa
+    git submodule init
 
-- ps: secure-file\tools\secure-file -decrypt build\resources\nylas\encrypted_certificates\appveyor\win-nylas-n1.p12.enc -secret $env:DECRYPTION_PASSWORD
-- ps: secure-file\tools\secure-file -decrypt build\resources\nylas\encrypted_certificates\appveyor\set_win_env.ps1.enc -secret $env:DECRYPTION_PASSWORD
-- ps: . build\resources\nylas\encrypted_certificates\appveyor\set_win_env.ps1
+    # http://stackoverflow.com/questions/21002919/running-a-remote-powershell-script-with-a-git-command-in-it-results-in-nativecom
+    Start-Process -FilePath git.exe -ArgumentList 'submodule update'  -Wait -NoNewWindow
+
+    secure-file\tools\secure-file -decrypt build\resources\nylas\encrypted_certificates\appveyor\win-nylas-n1.p12.enc -secret $env:DECRYPTION_PASSWORD
+    secure-file\tools\secure-file -decrypt build\resources\nylas\encrypted_certificates\appveyor\set_win_env.ps1.enc -secret $env:DECRYPTION_PASSWORD
+    . build\resources\nylas\encrypted_certificates\appveyor\set_win_env.ps1
+  }
 
 build_script:
 - ps: .\script\cibuild.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
 
 # We need to extract the encrypted private ssh key to clone the submodule.
 - ps: |
-    if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+    if ($env:DECRYPTION_PASSWORD) {
       secure-file\tools\secure-file -decrypt build\resources\ssh\nylas-n1-ci-ssh-secure-file.enc -secret $env:DECRYPTION_PASSWORD
       mv -Force build\resources\ssh\nylas-n1-ci-ssh-secure-file c:\users\appveyor\.ssh\id_rsa
       git submodule init

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,8 @@ deploy: off
 # We need to only clone the main module because our submodule requires the
 # encrypted ssh key to access submodules
 clone_depth: 1
-#build:
-#  verbosity: minimal
+build:
+  verbosity: minimal
 install:
 - ps: Install-Product node $env:NODE_VERSION $env:PLATFORM
 - ps: nuget install secure-file -ExcludeVersion

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,8 @@ deploy: off
 # We need to only clone the main module because our submodule requires the
 # encrypted ssh key to access submodules
 clone_depth: 1
-build:
-  verbosity: minimal
+#build:
+#  verbosity: minimal
 install:
 - ps: Install-Product node $env:NODE_VERSION $env:PLATFORM
 - ps: nuget install secure-file -ExcludeVersion


### PR DESCRIPTION
This PR wraps the statements requiring access to the secure variables in an `if` statement to check if the variables are set. This successfully builds N1, **but** I have no feasible way to check if N1 works under Windows. The build currently _fails_ with the `AWS_ACCESS_KEY_ID` environment variable not found for publishing the finished build to AWS S3.

The only computer I have Windows on is my old Lenovo X300 from 2008, which I really don't want to dust off and power it up.