### PR TITLE
Color the Trash icon a dark shade of red to make it more visually distinctive

### DIFF
--- a/internal_packages/message-list/lib/thread-trash-button.cjsx
+++ b/internal_packages/message-list/lib/thread-trash-button.cjsx
@@ -17,7 +17,7 @@ class ThreadTrashButton extends React.Component
     focusedMailViewFilter = FocusedMailViewStore.mailView()
     return false unless focusedMailViewFilter?.canTrashThreads()
 
-    <button className="btn btn-toolbar"
+    <button className="btn btn-toolbar btn-trash"
             style={order: -106}
             title="Move to Trash"
             onClick={@_onRemove}>

--- a/internal_packages/message-list/stylesheets/message-list.less
+++ b/internal_packages/message-list/stylesheets/message-list.less
@@ -88,6 +88,12 @@ body.platform-win32 {
   .message-toolbar-arrow.disabled {
     opacity: 0.3;
   }
+
+  .btn-trash {
+    img.content-mask {
+      background-color: darken(@btn-danger-bg-color, 15%);
+    }
+  }
 }
 
 .mode-split {


### PR DESCRIPTION
Referencing #794 where @colllin suggests making the trash icon more like Spark's trash icon to prevent confusion between the Archive and Trash icons.