### PR TITLE
Make test output selectable

### DIFF
--- a/static/jasmine.less
+++ b/static/jasmine.less
@@ -147,6 +147,8 @@ body {
     font-weight: bold;
     color: #d9534f;
     padding: 5px 0 5px 0;
+    -webkit-user-select: text;
+    user-select: text;
   }
 
   .result-message.deprecation-message {


### PR DESCRIPTION
Test error messages are unselectable by default. This PR adds the ability to select and copy error messages produced by the test suite.

![image](https://cloud.githubusercontent.com/assets/169280/12064287/6cb68d08-af74-11e5-8f77-0e99abef496e.png)
