### PR TITLE
Copy app icons to `hicolor` on Debian

### DIFF
--- a/script/mkdeb
+++ b/script/mkdeb
@@ -39,7 +39,7 @@ cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/icons/hicolor"
 for i in 256 128 64 32 16; do
   mkdir -p "$TARGET/usr/share/icons/hicolor/${i}x${i}/apps"
-  cp "icons/${i}.png" "$TARGET/usr/share/icons/hicolor/${i}x${i}/apps/nylas.png"
+  cp "$DEB_PATH/icons/${i}.png" "$TARGET/usr/share/icons/hicolor/${i}x${i}/apps/nylas.png"
 done
 
 # Copy generated LICENSE.md to /usr/share/doc/nylas/copyright

--- a/script/mkdeb
+++ b/script/mkdeb
@@ -36,6 +36,12 @@ cp "$DESKTOP_FILE" "$TARGET/usr/share/applications"
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/pixmaps"
 cp "$ICON_FILE" "$TARGET/usr/share/pixmaps"
 
+mkdir -m $FILE_MODE -p "$TARGET/usr/share/icons/hicolor"
+for i in 256 128 64 32 16; do
+  mkdir -p "$TARGET/usr/share/icons/hicolor/${i}x${i}/apps"
+  cp "icons/${i}.png" "$TARGET/usr/share/icons/hicolor/${i}x${i}/apps/nylas.png"
+done
+
 # Copy generated LICENSE.md to /usr/share/doc/nylas/copyright
 mkdir -m $FILE_MODE -p "$TARGET/usr/share/doc/nylas"
 cp "$TARGET/usr/share/nylas/resources/LICENSE.md" "$TARGET/usr/share/doc/nylas/copyright"


### PR DESCRIPTION
Debian searches the `hicolor` directory by default and the [`postinst`](https://github.com/nylas/N1/blob/master/build/resources/linux/debian/postinst#L23) script rebuilds the cache at install time. This addition will add the icons of each size to the `hicolor` directory.