### PR TITLE
Reorder archive and trash icons 

### DIFF
--- a/internal_packages/thread-list/lib/thread-list-quick-actions.cjsx
+++ b/internal_packages/thread-list/lib/thread-list-quick-actions.cjsx
@@ -16,7 +16,7 @@ class ThreadArchiveQuickAction extends React.Component
     if mailViewFilter?.canArchiveThreads()
       archive = <div key="archive"
                      title="Archive"
-                     style={{ order: 110 }}
+                     style={{ order: 100 }}
                      className="btn action action-archive"
                      onClick={@_onArchive}></div>
     return archive
@@ -45,7 +45,7 @@ class ThreadTrashQuickAction extends React.Component
     if mailViewFilter?.canTrashThreads()
       trash = <div key="remove"
                    title="Trash"
-                   style={{ order: 100 }}
+                   style={{ order: 110 }}
                    className='btn action action-trash'
                    onClick={@_onRemove}></div>
     return trash


### PR DESCRIPTION
Because of changes made in #892, the archive and trash quick action buttons were inserted in the wrong order as can be seen below:
![image](https://cloud.githubusercontent.com/assets/2907397/12152239/82a1add4-b481-11e5-8263-e0883497852b.png)
This fixes that issue so that they are in the same order as in the toolbar.

Sorry about this -- it was my fault for not checking before I submitted the previous pull request.