### PR TITLE
[ON HOLD] Account list overhaul

### DIFF
--- a/internal_packages/account-sidebar/lib/account-switcher.cjsx
+++ b/internal_packages/account-sidebar/lib/account-switcher.cjsx
@@ -22,10 +22,12 @@ class AccountSwitcher extends React.Component
   componentDidMount: =>
     @unsubscribers = []
     @unsubscribers.push AccountStore.listen @_onStoreChange
-    @unsubscribers.push Categories.forAllAccounts().sort().subscribe @_onCategoriesChanged
+
+    @dispose = Categories.forAllAccounts().sort().subscribe @_onCategoriesChanged
 
   componentWillUnmount: =>
     unsubscribe() for unsubscribe in @unsubscribers
+    @dispose?()
 
   render: =>
     return false unless @state.account

--- a/internal_packages/account-sidebar/lib/account-switcher.cjsx
+++ b/internal_packages/account-sidebar/lib/account-switcher.cjsx
@@ -22,6 +22,7 @@ class AccountSwitcher extends React.Component
   componentDidMount: =>
     @unsubscribers = []
     @unsubscribers.push AccountStore.listen @_onStoreChange
+    @unsubscribers.push ThreadCountsStore.listen @_onStoreChange
 
     @dispose = Categories.forAllAccounts().sort().subscribe @_onCategoriesChanged
 

--- a/internal_packages/account-sidebar/spec/account-switcher-spec.cjsx
+++ b/internal_packages/account-sidebar/spec/account-switcher-spec.cjsx
@@ -1,7 +1,7 @@
 React = require 'react/addons'
 TestUtils = React.addons.TestUtils
 AccountSwitcher = require './../lib/account-switcher'
-{AccountStore} = require 'nylas-exports'
+{AccountStore, Label} = require 'nylas-exports'
 
 describe "AccountSwitcher", ->
   switcher = null
@@ -14,6 +14,7 @@ describe "AccountSwitcher", ->
           emailAddress: "dillon@nylas.com",
           provider: "exchange"
           label: "work"
+          categoryClass: -> Label
         }
       ]
 
@@ -22,12 +23,8 @@ describe "AccountSwitcher", ->
     )
 
   it "shows other accounts and the 'Add Account' button", ->
-    toggler = TestUtils.findRenderedDOMComponentWithClass switcher, 'primary-item'
-    TestUtils.Simulate.click toggler
-
-    dropdown = TestUtils.findRenderedDOMComponentWithClass switcher, "dropdown"
-    items = TestUtils.scryRenderedDOMComponentsWithClass dropdown, "secondary-item"
-    newAccountButton = TestUtils.scryRenderedDOMComponentsWithClass dropdown, "new-account-option"
+    items = TestUtils.scryRenderedDOMComponentsWithClass switcher, "secondary-item"
+    newAccountButton = TestUtils.scryRenderedDOMComponentsWithClass switcher, "new-account-option"
 
     expect(items.length).toBe 3
     expect(newAccountButton.length).toBe 1

--- a/internal_packages/account-sidebar/spec/account-switcher-spec.cjsx
+++ b/internal_packages/account-sidebar/spec/account-switcher-spec.cjsx
@@ -21,24 +21,6 @@ describe "AccountSwitcher", ->
       <AccountSwitcher />
     )
 
-  it "doesn't render the dropdown if nothing clicked", ->
-    openDropdown = TestUtils.scryRenderedDOMComponentsWithClass switcher, 'open'
-    expect(openDropdown.length).toBe 0
-
-  it "shows the dropdown on click", ->
-    toggler = TestUtils.findRenderedDOMComponentWithClass switcher, 'primary-item'
-    TestUtils.Simulate.click toggler
-    openDropdown = TestUtils.scryRenderedDOMComponentsWithClass switcher, 'open'
-    expect(openDropdown.length).toBe 1
-
-  it "hides the dropdown on blur", ->
-    toggler = TestUtils.findRenderedDOMComponentWithClass switcher, 'primary-item'
-    TestUtils.Simulate.click toggler
-    toggler = TestUtils.findRenderedDOMComponentWithClass switcher, 'primary-item'
-    TestUtils.Simulate.blur toggler
-    openDropdown = TestUtils.scryRenderedDOMComponentsWithClass switcher, 'open'
-    expect(openDropdown.length).toBe 0
-
   it "shows other accounts and the 'Add Account' button", ->
     toggler = TestUtils.findRenderedDOMComponentWithClass switcher, 'primary-item'
     TestUtils.Simulate.click toggler

--- a/internal_packages/account-sidebar/stylesheets/account-sidebar.less
+++ b/internal_packages/account-sidebar/stylesheets/account-sidebar.less
@@ -129,6 +129,7 @@
 }
 
 #account-switcher {
+  background: lighten(@source-list-bg, 5%);
   border-bottom: 1px solid @border-color-divider;
 
   .primary-item {
@@ -151,23 +152,13 @@
   }
 
   .dropdown {
-    opacity: 0;
-    pointer-events: none;
-    transform:scale(1, 0.2);
-    transform-origin: top;
     transition: transform 125ms cubic-bezier(0.18, 0.89, 0.32, 1.12), opacity 100ms linear;
-    .inner {
-      opacity: 0;
-      transition: opacity 25ms linear;
-      transition-delay: 0;
-    }
     margin-top: -7px;
     background: lighten(@source-list-bg, 5%);
     border: 1px solid @border-color-divider;
     border-radius: @border-radius-base;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
-    box-shadow:  0 2px 4px 0 rgba(0, 0, 0, 0.21);
 
     position: absolute;
     top: 54px;
@@ -183,6 +174,7 @@
     position: relative;
     margin-bottom: 0;
     display:block;
+
     .gravatar {
       background-size: 28px 28px;
       width: 28px;
@@ -201,17 +193,12 @@
     }
 
     padding: 6px 5px 0 14px;
+  }
 
-    &:first-child {
-      padding-top: 8px;
-      border-top-left-radius: @list-border-radius;
-      border-top-right-radius: @list-border-radius;
-    }
-    &:last-child {
-      padding-bottom: 2px;
-      border-bottom-left-radius: @list-border-radius;
-      border-bottom-right-radius: @list-border-radius;
-    }
+  .active {
+    border-left: 3px solid @component-active-color;
+
+    padding-left: 11px;
   }
 }
 body.platform-win32 {
@@ -229,25 +216,6 @@ body.platform-win32 {
     }
   }
 }
-
-
-#account-switcher.open {
-  .dropdown {
-    opacity: 1;
-    pointer-events: initial;
-    transform:scale(1, 1);
-    transform-origin: top;
-    .inner {
-      opacity: 1;
-      transition: opacity 50ms linear;
-      transition-delay: 50ms;
-    }
-  }
-  .toggle {
-    transform: rotateX(0deg);
-  }
-}
-
 
 #account-switcher {
   height: auto;

--- a/src/global/nylas-observables.coffee
+++ b/src/global/nylas-observables.coffee
@@ -37,7 +37,10 @@ CategoryObservables =
     observable
 
   forAllAccounts: =>
-    observable = Rx.Observable.fromQuery(DatabaseStore.findAll(categoryClass))
+    observable = Rx.Observable.fromStore(AccountStore).flatMapLatest ->
+      observables = for account in AccountStore.items()
+        Rx.Observable.fromQuery(DatabaseStore.findAll(account.categoryClass()))
+      Rx.Observable.concat(observables)
     _.extend(observable, CategoryOperators)
     observable
 

--- a/src/global/nylas-observables.coffee
+++ b/src/global/nylas-observables.coffee
@@ -39,7 +39,11 @@ CategoryObservables =
   forAllAccounts: =>
     observable = Rx.Observable.fromStore(AccountStore).flatMapLatest ->
       observables = for account in AccountStore.items()
-        Rx.Observable.fromQuery(DatabaseStore.findAll(account.categoryClass()))
+        categoryClass = account.categoryClass() if account
+        if categoryClass
+          Rx.Observable.fromQuery(DatabaseStore.findAll(categoryClass))
+        else
+          Rx.Observable.from([])
       Rx.Observable.concat(observables)
     _.extend(observable, CategoryOperators)
     observable


### PR DESCRIPTION
This PR changes a whole lot. The removes the dropdown from `AccountSwitcher` and replaces the primary account with every entry from the dropdown with additions, like the active account indicator and _WIP_ unread count badge for each account.

I need feedback on **ALL** of the backend code changed. The `Observables` caused wacky errors in development sometimes with the dispose method being null during spec test runs.

**TODO**:
- Update the account switcher when the unread counts change, currently they update whenever the switcher updates and is inconsistent with the backend store