### PR TITLE
Standardize capitalization to am/pm, for message-list

### DIFF
--- a/internal_packages/message-list/lib/message-timestamp.cjsx
+++ b/internal_packages/message-list/lib/message-timestamp.cjsx
@@ -28,10 +28,10 @@ class MessageTimestamp extends React.Component
       diff = now.diff(msgDate, 'days', true)
       isSameDay = now.isSame(msgDate, 'days')
       if diff < 1 and isSameDay
-        return msgDate.format "h:mm a"
+        return msgDate.format "h:mm A"
       if diff < 1.5 and not isSameDay
         timeAgo = msgDate.from now
-        monthAndDay = msgDate.format "h:mm a"
+        monthAndDay = msgDate.format "h:mm A"
         return monthAndDay + " (" + timeAgo + ")"
       if diff >= 1.5 and diff < 365
         return msgDate.format "MMM D"

--- a/internal_packages/message-list/spec/message-timestamp-spec.cjsx
+++ b/internal_packages/message-list/spec/message-timestamp-spec.cjsx
@@ -4,7 +4,7 @@ TestUtils = React.addons.TestUtils
 MessageTimestamp = require '../lib/message-timestamp'
 
 msgTime = ->
-  moment([2010, 1, 14, 15, 25, 50, 125]) # Feb 14, 2010 at 3:25pm
+  moment([2010, 1, 14, 15, 25, 50, 125]) # Feb 14, 2010 at 3:25 PM
 
 describe "MessageTimestamp", ->
   beforeEach ->
@@ -23,14 +23,14 @@ describe "MessageTimestamp", ->
 
   it "displays the time from messages shown today", ->
     now = msgTime().add(2, 'hours')
-    expect(@item._formattedDate(msgTime(), now)).toBe "3:25 pm"
+    expect(@item._formattedDate(msgTime(), now)).toBe "3:25 PM"
 
   it "displays the time from messages yesterday with the relative time if it's less than 36 hours ago", ->
     now = msgTime().add(21, 'hours')
-    expect(@item._formattedDate(msgTime(), now)).toBe "3:25 pm (21 hours ago)"
+    expect(@item._formattedDate(msgTime(), now)).toBe "3:25 PM (21 hours ago)"
 
     now = msgTime().add(30, 'hours')
-    expect(@item._formattedDate(msgTime(), now)).toBe "3:25 pm (a day ago)"
+    expect(@item._formattedDate(msgTime(), now)).toBe "3:25 PM (a day ago)"
 
   it "displays month, day for messages less than a year ago, but more than 24 hours ago", ->
     now = msgTime().add(2, 'months')


### PR DESCRIPTION
The time format for closed vs. expanded in the message-list is not consistent.
Closed:
![screen shot 2016-01-11 at 17 06 13](https://cloud.githubusercontent.com/assets/632942/12251033/c76be1ae-b888-11e5-99b5-4b64b8cc20dd.png)

Expanded:
![screen shot 2016-01-11 at 17 06 19](https://cloud.githubusercontent.com/assets/632942/12251032/c76a12fc-b888-11e5-9abc-d0d0d796d70d.png)

A number of other things change, but if the time format is the same, it'll appear as though the only thing changing with the time is adding the date before it.

This patch fixes that.

I have no opinion on lowercase vs. uppercase. Switching it to lowercase was just an easier change.