### PR TITLE
Allow custom Sync Engine specified in `config.cson`

### DIFF
--- a/src/flux/nylas-api.coffee
+++ b/src/flux/nylas-api.coffee
@@ -152,8 +152,8 @@ class NylasAPI
       @AppID = 'n/a'
       @APIRoot = 'http://localhost:5555'
     else if env in ['custom']
-      @AppID = NylasEnv.config.get('env.AppID') or 'n/a'
-      @APIRoot = NylasEnv.config.get('env.APIRoot') or 'http://localhost:5555'
+      @AppID = NylasEnv.config.get('syncEngine.AppID') or 'n/a'
+      @APIRoot = NylasEnv.config.get('syncEngine.APIRoot') or 'http://localhost:5555'
 
     current = {@AppID, @APIRoot, @APITokens}
 

--- a/src/flux/nylas-api.coffee
+++ b/src/flux/nylas-api.coffee
@@ -151,6 +151,9 @@ class NylasAPI
     else if env in ['local']
       @AppID = 'n/a'
       @APIRoot = 'http://localhost:5555'
+    else if env in ['custom']
+      @AppID = NylasEnv.config.get('env.AppID') or 'n/a'
+      @APIRoot = NylasEnv.config.get('env.APIRoot') or 'http://localhost:5555'
 
     current = {@AppID, @APIRoot, @APITokens}
 


### PR DESCRIPTION
In the Slack chat, `niels` and `thomas` requested this feature to use their own Sync Engines hosted on their local networks. This PR allows a custom defined Sync Engine API Root and App ID.

While the config path can change to be more isolated in its own context, I believe the one I provided is suitable.