### PR TITLE
Set Phishing Detection package name to the correct value

### DIFF
--- a/internal_packages/phishing-detection/package.json
+++ b/internal_packages/phishing-detection/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "phishing",
+  "name": "phishing-detection",
   "version": "0.2.1",
   "main": "./lib/main",
   "license": "GPL-3.0",


### PR DESCRIPTION
This was posted by `pkortge` on the Slack chat.

The `package.json` file reported the package name as `phishing`, which is incorrect as the folder is named `phishing-detection`. This PR sets the `name` value in `package.json` to `phishing-detection` so N1 loads the package.