### PR TITLE
Allow additional parameters specified on command line

### DIFF
--- a/N1.sh
+++ b/N1.sh
@@ -22,5 +22,5 @@ if [ ! -e "$ELECTRON_PATH" ]; then
   exit 1
 fi
 
-$ELECTRON_PATH --executed-from="$(pwd)" --pid=$$ "$@" $N1_PATH
+$ELECTRON_PATH --executed-from="$(pwd)" --pid=$$ $N1_PATH "$@"
 exit $?


### PR DESCRIPTION
This prevents Electron saying it cannot find the main entrypoint, when using the `--test -s` parameters on the command line to spec test plugins.

I use this option when spec testing `email-pgp`, my PGP plugin, and want to use the N1 master repository instead of the installed N1.