### PR TITLE
Fix logic for en_US default dictionary on Linux

### DIFF
--- a/src/nylas-spellchecker.coffee
+++ b/src/nylas-spellchecker.coffee
@@ -12,7 +12,7 @@ class NylasSpellchecker
   isLanguageAvailable: (lang) =>
     return false unless lang
     dicts = @getAvailableDictionaries()
-    return (lang in dicts) or (lang.replace('_', '-') in dicts) or (lang.replace('-', '_') in dicts)
+    return (lang in dicts) or (lang.split(/[-_]/)[0] in dicts) or (lang.replace('_', '-') in dicts) or (lang.replace('-', '_') in dicts)
 
   isSpelledCorrectly: (args...) => not @isMisspelled(args...)
 

--- a/src/nylas-spellchecker.coffee
+++ b/src/nylas-spellchecker.coffee
@@ -76,7 +76,7 @@ class NylasSpellchecker
   getAvailableDictionaries: ->
     if process.platform is 'linux'
       arr = spellchecker.getAvailableDictionaries()
-      if not "en_US" in arr
+      if "en_US" not in arr
         arr.push('en_US') # Installed by default in node-spellchecker's vendor directory
       arr
     else

--- a/src/nylas-spellchecker.coffee
+++ b/src/nylas-spellchecker.coffee
@@ -12,7 +12,7 @@ class NylasSpellchecker
   isLanguageAvailable: (lang) =>
     return false unless lang
     dicts = @getAvailableDictionaries()
-    return (lang in dicts) or (lang.split(/[-_]/)[0] in dicts)
+    return (lang in dicts) or (lang.replace('_', '-') in dicts) or (lang.replace('-', '_') in dicts)
 
   isSpelledCorrectly: (args...) => not @isMisspelled(args...)
 


### PR DESCRIPTION
The logic uses `if not` for CoffeeScript, but this checks if the constant `"en_US"` is not null, which is not the intended function of the check.

This PR fixes the intended functionality of the function and moves the `not` call to `in`.