### PR TITLE
Added cmd+a / ctrl+a for Outlook template threadlist selection

### DIFF
--- a/keymaps/templates/Outlook.cson
+++ b/keymaps/templates/Outlook.cson
@@ -3,6 +3,10 @@
 
 'body':
   # Windows email-specific menu items
+  
+  ### Threadlist selection ###
+  'cmdctrl-a':       'multiselect-list:select-all'
+  
   'cmdctrl-shift-v': 'application:change-category' # Outlook
   'F3':              'application:focus-search'
   'cmdctrl-e':       'application:focus-search'

--- a/src/flux/stores/account-store.coffee
+++ b/src/flux/stores/account-store.coffee
@@ -136,14 +136,14 @@ class AccountStore
     @_cachedGetter "accountForId:#{id}", => _.findWhere(@_accounts, {id})
 
   aliases: =>
-      aliases = []
-      for acc in @_accounts
-        aliases.push(acc.me())
-        for alias in acc.aliases
-          aliasContact = acc.meUsingAlias(alias)
-          aliasContact.isAlias = true
-          aliases.push(aliasContact)
-      return aliases
+    aliases = []
+    for acc in @_accounts
+      aliases.push(acc.me())
+      for alias in acc.aliases
+        aliasContact = acc.meUsingAlias(alias)
+        aliasContact.isAlias = true
+        aliases.push(aliasContact)
+    return aliases
 
   aliasesFor: (accountsOrIds) =>
     ids = accountsOrIds.map (accOrId) ->


### PR DESCRIPTION
This functionality is consistent with Outlook's web app and mac/windows apps