### PR TITLE
Bump grunt-contrib-csslint to to ~0.5.0

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -25,7 +25,7 @@
     "grunt-coffeelint": "git+https://github.com/atom/grunt-coffeelint.git#cfb99aa99811d52687969532bd5a98011ed95bfe",
     "grunt-coffeelint-cjsx": "^0.1",
     "grunt-contrib-coffee": "~0.12.0",
-    "grunt-contrib-csslint": "~0.1.2",
+    "grunt-contrib-csslint": "~0.5.0",
     "grunt-contrib-less": "~0.8.0",
     "grunt-cson": "0.14.0",
     "grunt-download-electron": "^2.1",


### PR DESCRIPTION
This addresses #1176. `csslint` removed the `package.json` `os` property in `0.10.0`. `grunt-contrib-csslint` updated to `csslint` in `0.2.0`. Atom uses `0.2.0`, but N1 can be better and use a newer version of the module.