### PR TITLE
Define the remote variable

### DIFF
--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -133,6 +133,7 @@ class WindowEventHandler
     return (unloadCallbacksRunning is 0)
 
   runUnloadFinished: ->
+    {remote} = require('electron')
     _.defer ->
       if remote.getGlobal('application').quitting
         remote.require('app').quit()


### PR DESCRIPTION
This code triggers when a window is supposed to close, but this error causes the DevTools to open and the window not exiting with the keyboard shortcut.

Please tell me if you want the `remote` module variable assignment within the `_.defer` block.