### PR TITLE
[RFC] Linux 32-bit Docker build

### DIFF
--- a/build/tasks/publish-nylas-build-task.coffee
+++ b/build/tasks/publish-nylas-build-task.coffee
@@ -10,7 +10,7 @@ packageVersion = null
 fullVersion = null
 
 module.exports = (grunt) ->
-  {cp, spawn, rm} = require('./task-helpers')(grunt)
+  {cp, shouldPublishBuild, spawn, rm} = require('./task-helpers')(grunt)
 
   appName = -> grunt.config.get('nylasGruntConfig.appName')
   dmgName = -> "#{appName().split('.')[0]}.dmg"
@@ -125,6 +125,8 @@ module.exports = (grunt) ->
         uploadToS3(buildZipFilename, key).then(resolve).catch(reject)
 
   grunt.registerTask "publish-nylas-build", "Publish Nylas build", ->
+    return false if not shouldPublishBuild()
+
     awsKey = process.env.AWS_ACCESS_KEY_ID ? ""
     awsSecret = process.env.AWS_SECRET_ACCESS_KEY ? ""
 

--- a/build/tasks/publish-nylas-build-task.coffee
+++ b/build/tasks/publish-nylas-build-task.coffee
@@ -125,7 +125,7 @@ module.exports = (grunt) ->
         uploadToS3(buildZipFilename, key).then(resolve).catch(reject)
 
   grunt.registerTask "publish-nylas-build", "Publish Nylas build", ->
-    return false if not shouldPublishBuild()
+    return unless shouldPublishBuild()
 
     awsKey = process.env.AWS_ACCESS_KEY_ID ? ""
     awsSecret = process.env.AWS_SECRET_ACCESS_KEY ? ""

--- a/docker/ubuntu32/Dockerfile
+++ b/docker/ubuntu32/Dockerfile
@@ -1,0 +1,34 @@
+# VERSION:        0.1
+# DESCRIPTION:    Image to build N1 and create a .deb and .rpm file for 32-bit systems, derived from Atom's Dockerfile
+
+# Base docker image
+FROM 32bit/ubuntu:14.04
+
+# Force noninteractive mode
+ENV DEBIAN_FRONTEND noninteractive
+
+# Setup NodeSource repository for Node LTS v4.x
+RUN apt-get update && apt-get install -y curl
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+
+# Correct errors with libpam-systemd (indirect dependency of libnotify4)
+RUN /bin/ln -sf /bin/true /sbin/initctl
+RUN /usr/bin/touch /etc/init.d/systemd-logind
+
+# Install dependencies (NodeSource setup runs `apt-get update` for us)
+RUN apt-get -y install \
+    build-essential \
+    git \
+    fakeroot \
+    libgconf2-4 \
+    libgnome-keyring-dev \
+    libgtk2.0-0 \
+    libnotify4 \
+    rpm \
+    nodejs \
+    xvfb
+
+#RUN npm install -g npm@3.3.10 --loglevel error
+
+ADD . /n1
+WORKDIR /n1

--- a/docker/ubuntu32/Dockerfile
+++ b/docker/ubuntu32/Dockerfile
@@ -20,13 +20,15 @@ RUN apt-get -y install \
     build-essential \
     git \
     fakeroot \
-    libgconf2-4 \
-    libgnome-keyring-dev \
-    libgtk2.0-0 \
-    libnotify4 \
     rpm \
-    nodejs \
-    xvfb
+    nodejs
+
+# For when Linux testing is re-enabled
+#    libgconf2-4 \
+#    libgnome-keyring-dev \
+#    libgtk2.0-0 \
+#    libnotify4 \
+#    xvfb
 
 #RUN npm install -g npm@3.3.10 --loglevel error
 

--- a/docker/ubuntu32/Dockerfile
+++ b/docker/ubuntu32/Dockerfile
@@ -20,13 +20,13 @@ RUN apt-get -y install \
     build-essential \
     fakeroot \
     git \
+    libgnome-keyring-dev \
     python \
     rpm \
     nodejs
 
 # For when Linux testing is re-enabled
 #    libgconf2-4 \
-#    libgnome-keyring-dev \
 #    libgtk2.0-0 \
 #    libnotify4 \
 #    xvfb

--- a/docker/ubuntu32/Dockerfile
+++ b/docker/ubuntu32/Dockerfile
@@ -18,8 +18,9 @@ RUN /usr/bin/touch /etc/init.d/systemd-logind
 # Install dependencies (NodeSource setup runs `apt-get update` for us)
 RUN apt-get -y install \
     build-essential \
-    git \
     fakeroot \
+    git \
+    python \
     rpm \
     nodejs
 

--- a/script/cibuild-n1-ubuntu32
+++ b/script/cibuild-n1-ubuntu32
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# --rm \
+docker build -t n1-32 -f ./docker/ubuntu32/Dockerfile .
+docker run \
+ --env="CI=true" \
+ --volume="$HOME"/.npm:/root/.npm \
+ --volume="$HOME"/.nylas/.apm:/root/.nylas/.apm \
+ --volume="$HOME"/.nylas/electron:/root/.nylas/electron \
+ n1-32 /usr/bin/linux32 /n1/script/cibuild
+docker rmi n1-32

--- a/script/cibuild-n1-ubuntu32
+++ b/script/cibuild-n1-ubuntu32
@@ -5,7 +5,7 @@ set -e
 # --rm \
 docker build -t n1-32 -f ./docker/ubuntu32/Dockerfile .
 docker run \
- --env PUBLISH_BUILD="$PUBLIC_BUILD" \
+ --env PUBLISH_BUILD="$PUBLISH_BUILD" \
  --env TRAVIS="$TRAVIS" \
  --env TRAVIS_PULL_REQUEST="$TRAVIS_PULL_REQUEST" \
  --env TRAVIS_BRANCH="$TRAVIS_BRANCH" \

--- a/script/cibuild-n1-ubuntu32
+++ b/script/cibuild-n1-ubuntu32
@@ -5,9 +5,9 @@ set -e
 # --rm \
 docker build -t n1-32 -f ./docker/ubuntu32/Dockerfile .
 docker run \
- --env="CI=true" \
- --volume="$HOME"/.npm:/root/.npm \
- --volume="$HOME"/.nylas/.apm:/root/.nylas/.apm \
- --volume="$HOME"/.nylas/electron:/root/.nylas/electron \
- n1-32 /usr/bin/linux32 /n1/script/cibuild
+ --env PUBLISH_BUILD="$PUBLIC_BUILD" \
+ --env TRAVIS="$TRAVIS" \
+ --env TRAVIS_PULL_REQUEST="$TRAVIS_PULL_REQUEST" \
+ --env TRAVIS_BRANCH="$TRAVIS_BRANCH" \
+ n1-32 /usr/bin/linux32 /n1/script/dockerbuild
 docker rmi n1-32

--- a/script/dockerbuild
+++ b/script/dockerbuild
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+script/build
+script/grunt mkdeb mkrpm publish-nylas-build --stack --no-color --install-dir /usr

--- a/script/mkrpm
+++ b/script/mkrpm
@@ -13,7 +13,7 @@ ARCH=`uname -m`
 
 # Work around for `uname -m` returning i686 when rpmbuild uses i386 instead
 if [ "$ARCH" = "i686" ]; then
-	ARCH = "i386"
+	ARCH="i386"
 fi
 
 # rpmdev-setuptree

--- a/script/mkrpm
+++ b/script/mkrpm
@@ -12,7 +12,7 @@ RPM_BUILD_ROOT=~/rpmbuild
 ARCH=`uname -m`
 
 # Work around for `uname -m` returning i686 when rpmbuild uses i386 instead
-if [ "$ARCH" = "i686" ];
+if [ "$ARCH" = "i686" ]; then
 	ARCH = "i386"
 fi
 

--- a/script/mkrpm
+++ b/script/mkrpm
@@ -11,6 +11,11 @@ APP_FILE_NAME="$5"
 RPM_BUILD_ROOT=~/rpmbuild
 ARCH=`uname -m`
 
+# Work around for `uname -m` returning i686 when rpmbuild uses i386 instead
+if [ "$ARCH" = "i686" ];
+	ARCH = "i386"
+fi
+
 # rpmdev-setuptree
 mkdir -p $RPM_BUILD_ROOT/BUILD
 mkdir -p $RPM_BUILD_ROOT/SPECS


### PR DESCRIPTION
In response to #254 and #139, I developed a Docker build for Linux that uses a 32-bit Docker image and builds N1. I used Atom's Fedora Docker buildfile as a template and went from there.

This PR adds the ability to use the Docker build, but needs complete testing for the `publish-nylas-build` task.

I was able to get the Docker to build the `deb` and `rpm` files like the regular CI build process does.