### PR TITLE
README Update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,7 @@ however, the Sync Engine is open source and you can run it yourself.
    API Root, for example `192.168.1.00:5555`
 
    ```
+   env: "custom"
    syncEngine:
      APIRoot: "http://192.168.1.100:5555"
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,16 @@ however, the Sync Engine is open source and you can run it yourself.
 
    ```
    syncEngine:
-     APIRoot: http://mysite.com:5555
+     APIRoot: "http://mysite.com:5555"
+   ```
+
+   NOTE: If you are using a custom network layout and your sync engine is not on
+   `localhost:5555`, use `env: custom` instead along with your alternate IP for the
+   API Root, for example `192.168.1.00:5555`
+
+   ```
+   syncEngine:
+     APIRoot: "http://192.168.1.100:5555"
    ```
 
    Copy the JSON array of accounts returned from the Sync Engine's `/accounts`


### PR DESCRIPTION
Updating Contributing guidelines to make note of the `env: custom` option so that a Sync Engine in a local environment may be accessed on an alternate IP.

Also APIRoot must contain quotes around the URL otherwise a config validation will be thrown.

Signed-off-by: Julien Chinapen <j.c@shogun.io>