### PR TITLE
Correct eslint errors from Travis

### DIFF
--- a/internal_packages/composer-spellcheck/lib/spellcheck-composer-extension.es6
+++ b/internal_packages/composer-spellcheck/lib/spellcheck-composer-extension.es6
@@ -113,7 +113,7 @@ export default class SpellcheckComposerExtension extends ComposerExtension {
   // Traverses all of the text nodes within the provided `editor`. If it finds a
   // text node with a misspelled word, it splits it, wraps the misspelled word
   // with a <spelling> node and updates the selection to account for the change.
-  static _wrapMisspelledWords = (editor)=> {
+  static _wrapMisspelledWords = (editor) => {
     SpellcheckComposerExtension._whileApplyingSelectionChanges((selectionSnapshot)=> {
       const treeWalker = document.createTreeWalker(editor.rootNode, NodeFilter.SHOW_TEXT);
       const nodeList = [];
@@ -179,14 +179,15 @@ export default class SpellcheckComposerExtension extends ComposerExtension {
     });
   }
 
-  static finalizeSessionBeforeSending = ({session})=> {
+  static finalizeSessionBeforeSending = ({session}) => {
     const body = session.draft().body;
     const clean = body.replace(/<\/?spelling[^>]*>/g, '');
+
     if (body !== clean) {
       return session.changes.add({body: clean});
-    } else {
-      return Promise.resolve();
     }
+
+    return Promise.resolve();
   }
 }
 

--- a/internal_packages/message-autoload-images/spec/autoload-images-extension-spec.es6
+++ b/internal_packages/message-autoload-images/spec/autoload-images-extension-spec.es6
@@ -1,15 +1,17 @@
 import fs from 'fs';
+import path from 'path';
 import AutoloadImagesExtension from '../lib/autoload-images-extension';
 import AutoloadImagesStore from '../lib/autoload-images-store';
 
-describe("AutoloadImagesExtension", ()=> {
-  describe("formatMessageBody", ()=> {
+describe("AutoloadImagesExtension", () => {
+  describe("formatMessageBody", () => {
     const scenarios = [];
     const fixtures = path.resolve(path.join(__dirname, 'fixtures'));
 
-    fs.readdirSync(fixtures).forEach((filename)=> {
+    fs.readdirSync(fixtures).forEach((filename) => {
       if (filename.endsWith('-in.html')) {
         const name = filename.replace('-in.html', '');
+
         scenarios.push({
           name: name,
           in: fs.readFileSync(path.join(fixtures, filename)).toString(),
@@ -19,13 +21,15 @@ describe("AutoloadImagesExtension", ()=> {
     });
 
     scenarios.forEach((scenario)=> {
-      it(`should process ${scenario.name}`, ()=> {
+      it(`should process ${scenario.name}`, () => {
         spyOn(AutoloadImagesStore, 'shouldBlockImagesIn').andReturn(true);
-        message = {
-          body: scenario.in
+
+        const message = {
+          body: scenario.in,
         };
         AutoloadImagesExtension.formatMessageBody({message});
-        expect(message.body == scenario.out).toBe(true);
+
+        expect(message.body === scenario.out).toBe(true);
       });
     });
   });


### PR DESCRIPTION
There are warnings in `spellcheck-composer-extension.es6` for the `while (true)` loops.

I do not know a better way off the top of my head, but these fixes will allow the Travis builds to complete and not fail. I am surprised my Travis builds from my personal fork still succeed.