### PR TITLE
Fixes scrollbar display when content is not scrollable

### DIFF
--- a/src/components/scroll-region.cjsx
+++ b/src/components/scroll-region.cjsx
@@ -100,6 +100,7 @@ class Scrollbar extends React.Component
     bottom: 0
     right: 0
     zIndex: 2
+    visibility: "hidden" if @state.totalHeight != 0 && @state.totalHeight == @state.viewportHeight
 
   _onHandleDown: (event) =>
     handleNode = React.findDOMNode(@refs.handle)

--- a/src/components/scroll-region.cjsx
+++ b/src/components/scroll-region.cjsx
@@ -100,7 +100,7 @@ class Scrollbar extends React.Component
     bottom: 0
     right: 0
     zIndex: 2
-    visibility: "hidden" if @state.totalHeight != 0 && @state.totalHeight == @state.viewportHeight
+    visibility: if @state.totalHeight != 0 && @state.totalHeight == @state.viewportHeight then "hidden" else "visible"
 
   _onHandleDown: (event) =>
     handleNode = React.findDOMNode(@refs.handle)
@@ -197,6 +197,10 @@ class ScrollRegion extends React.Component
       attributeOldValue: true,
       attributeFilter: ['style']
     })
+
+  componentDidUpdate: (prevProps, prevState) =>
+    if (@props.children != prevProps.children)
+      @recomputeDimensions()
 
   componentWillReceiveProps: (props) =>
     if @shouldInvalidateScrollbarComponent(props)


### PR DESCRIPTION
Scrollbars are currently always shown on hover, even if the content is fully fitted in the viewport. Extraneous scrollbars feel non-native; fixes #1008.

<img width="240" alt="screen shot 2016-03-10 at 5 55 45 pm" src="https://cloud.githubusercontent.com/assets/388552/13691005/06af35ca-e6ea-11e5-9603-ac8dbbc84252.png">