### PR TITLE
Fixes scrollbar display when content is not scrollable

### DIFF
--- a/src/components/scroll-region.cjsx
+++ b/src/components/scroll-region.cjsx
@@ -100,6 +100,7 @@ class Scrollbar extends React.Component
     bottom: 0
     right: 0
     zIndex: 2
+    visibility: "hidden" if @state.totalHeight != 0 && @state.totalHeight == @state.viewportHeight
 
   _onHandleDown: (event) =>
     handleNode = React.findDOMNode(@refs.handle)

--- a/src/components/scroll-region.cjsx
+++ b/src/components/scroll-region.cjsx
@@ -198,6 +198,10 @@ class ScrollRegion extends React.Component
       attributeFilter: ['style']
     })
 
+  componentDidUpdate: (prevProps, prevState) =>
+    if (@props.children != prevProps.children)
+      @recomputeDimensions()
+
   componentWillReceiveProps: (props) =>
     if @shouldInvalidateScrollbarComponent(props)
       @_scrollbarComponent = null


### PR DESCRIPTION
Scrollbars are currently always shown on hover, even if the content is fully fitted in the viewport, and has a non-native feel.

Fixing that requires correctly updating scrollbar state with content changes. For example, if the scrollbar is displayed (hovered) while page height is changed (e.g. a new message comes in), interacting with the scrollbar causes erratic behavior. This PR fixes that.

Fixes #1008.

<img width="240" alt="screen shot" src="https://cloud.githubusercontent.com/assets/388552/13691005/06af35ca-e6ea-11e5-9603-ac8dbbc84252.png">