### PR TITLE
Open links in background when ⌘ key is pressed

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/nylas/N1/issues"
   },
-  "electronVersion": "0.36.7",
+  "electronVersion": "0.36.9",
   "dependencies": {
     "async": "^0.9",
     "atom-keymap": "^6.1.1",

--- a/src/components/evented-iframe.cjsx
+++ b/src/components/evented-iframe.cjsx
@@ -143,7 +143,7 @@ class EventedIFrame extends React.Component
           target.setAttribute('href', "http://#{rawHref}")
 
       e.preventDefault()
-      NylasEnv.windowEventHandler.openLink(target: target)
+      NylasEnv.windowEventHandler.openLink(target: target, metaKey: e.metaKey)
 
   _isBlacklistedHref: (href) ->
     return (new RegExp(/^file:/i)).test(href)

--- a/src/window-event-handler.coffee
+++ b/src/window-event-handler.coffee
@@ -175,7 +175,7 @@ class WindowEventHandler
     event.preventDefault()
     event.stopPropagation()
 
-  openLink: ({href, target, currentTarget}) ->
+  openLink: ({href, target, currentTarget, metaKey}) ->
     if not href
       href = target?.getAttribute('href') or currentTarget?.getAttribute('href')
 
@@ -192,7 +192,7 @@ class WindowEventHandler
       # *might* apply to http/https as well but it's unclear.
       shell.openExternal(encodeURI(decodeURI(href)))
     else if schema in ['http:', 'https:', 'tel:']
-      shell.openExternal(href)
+      shell.openExternal(href, activate: !metaKey)
 
     return
 


### PR DESCRIPTION
When you hold down the meta key (⌘), and click on a link in a message,
the target application will not activate, so N1 will stay in the
foreground.

NB. The update of Electron is required to support (could be `0.36.8` as well), but I noticed that the upgrade was made previously, and reverted due to issues. (#847 #911)

Electron currently only supports this for OS X: https://github.com/atom/electron/blob/master/docs/api/shell.md#shellopenexternalurl-options

Fixes #181 