### PR TITLE
(darkside) Fixed alignment of message headers

### DIFF
--- a/internal_packages/ui-darkside/styles/darkside.less
+++ b/internal_packages/ui-darkside/styles/darkside.less
@@ -525,7 +525,8 @@ body.is-blurred .list-tabular .list-tabular-item.keyboard-cursor {
 #message-list .message-subject-wrap,
 #message-list .message-item-wrap,
 #message-list .footer-reply-area-wrap,
-#message-list .minified-bundle .msg-lines {
+#message-list .minified-bundle .msg-lines,
+#message-list .message-list-headers {
   max-width: @message-width;
 }
 


### PR DESCRIPTION
like the phishing indicator in the darkside theme.

Before this change: http://pasteboard.co/2bUg8PU9.png
After: http://pasteboard.co/2bUj2Bmz.png