### PR TITLE
Add atom-keytar for use in extensions

### DIFF
--- a/src/global/nylas-exports.coffee
+++ b/src/global/nylas-exports.coffee
@@ -156,7 +156,7 @@ class NylasExports
   @get "React", -> require 'react' # Our version of React for 3rd party use
   @get "Reflux", -> require 'reflux'
   @get "Rx", -> require 'rx-lite'
-  @get "Keychain", -> require 'keytar' # Keychain access through native module
+  @get "Keytar", -> require 'keytar' # atom-keytar access through native module
 
   # React Components
   @load "ReactRemote", 'react-remote/react-remote-parent'

--- a/src/global/nylas-exports.coffee
+++ b/src/global/nylas-exports.coffee
@@ -156,6 +156,7 @@ class NylasExports
   @get "React", -> require 'react' # Our version of React for 3rd party use
   @get "Reflux", -> require 'reflux'
   @get "Rx", -> require 'rx-lite'
+  @get "Keychain", -> require 'keytar' # Keychain access through native module
 
   # React Components
   @load "ReactRemote", 'react-remote/react-remote-parent'


### PR DESCRIPTION
In Cypher, I store the Keybase tokens in `config.cson` currently. With the recent integration of `atom-keytar`, I can store those authentication tokens into the system keychain where they are better protected than `config.cson` just like the account tokens.