### PR TITLE
Enhance issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,25 +1,37 @@
+<!--
 Thanks for taking the time to file an issue! If you have general question or a problem with your email account, take a quick look at the N1 Knowledge Base to see if you question is addressed there:
-
-https://support.nylas.com/hc/en-us/sections/203638587-N1_
-
+   
+   https://support.nylas.com/hc/en-us/sections/203638587-N1_
+   
 Our team tries to respond to all GitHub issues. To make sure your issue is
 actionable, try to include the following information:
+-->
 
-- Are there any related issues? Try searching for both open and closed issues here: https://github.com/nylas/N1/issues?q=is%3Aissue. Keep in mind that email features are often described differently on different platforms. (Conversations == threads, shortcuts == hotkeys, etc.)
+##### Are there any related issues?
+<!-- Try searching for both open and closed issues here: https://github.com/nylas/N1/issues?q=is%3Aissue. Keep in mind that email features are often described differently on different platforms. (Conversations == threads, shortcuts == hotkeys, etc.) -->
+...
 
-- What operating system are you using?
+##### What operating system are you using?
+...
 
-- What version of N1 are you using?
+##### What version of N1 are you using?
+...
 
+--
 
 **Bug?**
-- Do you have any third-party plugins installed?
+##### Do you have any third-party plugins installed?
+...
 
-- Is the issue related to a specific email provider (Gmail, Exchange, etc.)?
+##### Is the issue related to a specific email provider (Gmail, Exchange, etc.)?
+...
 
-- Is the issue reproducible with a particular attachment, message, signature, etc?
-   Try to provide an example as a file attachment or a screenshot.
+##### Is the issue reproducible with a particular attachment, message, signature, etc?
+<!-- Try to provide an example as a file attachment or a screenshot. -->
+...
 
+--
 
 **Feature Request?**
-- Does this feature exist in another mail client or tool you use?
+##### Does this feature exist in another mail client or tool you use?
+...


### PR DESCRIPTION
There were several issues with the last issue template, here are some of them

- Instructions to user that should've been comments were not, they were shown as part of the issue
- Bullets were used instead of heading, the down side is that they weren't gonna be bullets only. Users were supposed to add paragraphs below them, thus breaking the styling.
- There were no separators in place

This PR addresses these issues