### PR TITLE
Use `remote` exports instead of `remote.require` for dialog

### DIFF
--- a/spec/stores/draft-store-spec.coffee
+++ b/spec/stores/draft-store-spec.coffee
@@ -785,16 +785,15 @@ describe "DraftStore", ->
       spyOn(NylasEnv, "isMainWindow").andReturn true
       spyOn(FocusedContentStore, "focused").andReturn(id: "t1")
       {remote} = require('electron')
-      dialog = remote.require('dialog')
-      spyOn(dialog, "showMessageBox")
+      spyOn(remote.dialog, "showMessageBox")
       spyOn(Actions, "composePopoutDraft")
       DraftStore._draftsSending[@draft.clientId] = true
       Actions.draftSendingFailed({threadId: 't1', errorMessage: "boohoo", draftClientId: @draft.clientId})
       advanceClock(200)
       expect(DraftStore.isSendingDraft(@draft.clientId)).toBe false
       expect(DraftStore.trigger).toHaveBeenCalledWith(@draft.clientId)
-      expect(dialog.showMessageBox).toHaveBeenCalled()
-      dialogArgs = dialog.showMessageBox.mostRecentCall.args[1]
+      expect(remote.dialog.showMessageBox).toHaveBeenCalled()
+      dialogArgs = remote.dialog.showMessageBox.mostRecentCall.args[1]
       expect(dialogArgs.detail).toEqual("boohoo")
       expect(Actions.composePopoutDraft).not.toHaveBeenCalled
 

--- a/src/browser/auto-update-manager.coffee
+++ b/src/browser/auto-update-manager.coffee
@@ -1,9 +1,11 @@
-autoUpdater = null
 _ = require 'underscore'
+{dialog} = require 'electron'
 {EventEmitter} = require 'events'
 uuid = require 'node-uuid'
 path = require 'path'
 fs = require 'fs'
+
+autoUpdater = null
 
 IdleState = 'idle'
 CheckingState = 'checking'
@@ -123,8 +125,7 @@ class AutoUpdateManager
 
   onUpdateNotAvailable: =>
     autoUpdater.removeListener 'error', @onUpdateError
-    {dialog} = require 'electron'
-    dialog.showMessageBox
+    remote.dialog.showMessageBox
       type: 'info'
       buttons: ['OK']
       icon: @iconURL()
@@ -134,7 +135,6 @@ class AutoUpdateManager
 
   onUpdateError: (event, message) =>
     autoUpdater.removeListener 'update-not-available', @onUpdateNotAvailable
-    {dialog} = require 'electron'
     dialog.showMessageBox
       type: 'warning'
       buttons: ['OK']

--- a/src/browser/nylas-window.coffee
+++ b/src/browser/nylas-window.coffee
@@ -1,4 +1,4 @@
-{BrowserWindow, app} = require 'electron'
+{BrowserWindow, app, dialog} = require 'electron'
 path = require 'path'
 fs = require 'fs'
 url = require 'url'
@@ -184,7 +184,6 @@ class NylasWindow
       return if @isSpec
       return if not @loaded
 
-      {dialog} = require 'electron'
       chosen = dialog.showMessageBox @browserWindow,
         type: 'warning'
         buttons: ['Close', 'Keep Waiting']
@@ -198,7 +197,6 @@ class NylasWindow
       if @neverClose
         @browserWindow.reload()
       else
-        {dialog} = require 'electron'
         chosen = dialog.showMessageBox @browserWindow,
           type: 'warning'
           buttons: ['Close Window', 'Reload', 'Keep It Open']

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore'
 _ = _.extend(_, require('./config-utils'))
+{remote} = require 'electron'
 fs = require 'fs-plus'
 EmitterMixin = require('emissary').Emitter
 {CompositeDisposable, Disposable, Emitter} = require 'event-kit'
@@ -16,7 +17,7 @@ ScopeDescriptor = require './scope-descriptor'
 if global.application
   app = global.application
 else
-  app = require('remote').getGlobal('application')
+  app = remote.getGlobal('application')
 
 # Essential: Used to access all of N1's configuration details.
 #

--- a/src/flux/nylas-api.coffee
+++ b/src/flux/nylas-api.coffee
@@ -1,4 +1,5 @@
 _ = require 'underscore'
+{remote} = require 'electron'
 request = require 'request'
 Utils = require './models/utils'
 Account = require './models/account'
@@ -457,9 +458,8 @@ class NylasAPI
         return Promise.resolve()
 
   _requestPluginAuth: (pluginName, account) ->
-    {dialog} = require('electron').remote
     return new Promise( (resolve, reject) =>
-      dialog.showMessageBox({
+      remote.dialog.showMessageBox({
         title: "Plugin Offline Email Access",
         message: "The N1 plugin #{pluginName} requests offline access to your email.",
         detail: "The #{pluginName} plugin would like to be able to access your email \

--- a/src/flux/stores/file-download-store.coffee
+++ b/src/flux/stores/file-download-store.coffee
@@ -1,7 +1,7 @@
 os = require 'os'
 fs = require 'fs'
 path = require 'path'
-{shell} = require 'electron'
+{remote, shell} = require 'electron'
 mkdirp = require 'mkdirp'
 Utils = require '../models/utils'
 Reflux = require 'reflux'
@@ -252,8 +252,7 @@ FileDownloadStore = Reflux.createStore
     path.join(downloadDir, filesafeName)
 
   _presentError: (file) ->
-    dialog = require('remote').require('dialog')
-    dialog.showMessageBox
+    remote.dialog.showMessageBox
       type: 'warning'
       message: "Download Failed"
       detail: "Unable to download #{file.displayName()}.

--- a/src/nylas-env.coffee
+++ b/src/nylas-env.coffee
@@ -787,8 +787,7 @@ class NylasEnvConstructor extends Model
     else
       buttonLabels = Object.keys(buttons)
 
-    dialog = remote.require('dialog')
-    chosen = dialog.showMessageBox @getCurrentWindow(),
+    chosen = remote.dialog.showMessageBox @getCurrentWindow(),
       type: 'info'
       message: message
       detail: detailedMessage
@@ -857,13 +856,11 @@ class NylasEnvConstructor extends Model
     remote.process.exit(status)
 
   showOpenDialog: (options, callback) ->
-    dialog = remote.require('dialog')
-    callback(dialog.showOpenDialog(@getCurrentWindow(), options))
+    callback(remote.dialog.showOpenDialog(@getCurrentWindow(), options))
 
   showSaveDialog: (options, callback) ->
     options.title ?= 'Save File'
-    dialog = remote.require('dialog')
-    callback(dialog.showSaveDialog(@getCurrentWindow(), options))
+    callback(remote.dialog.showSaveDialog(@getCurrentWindow(), options))
 
   showErrorDialog: (messageData) ->
     if _.isString(messageData) or _.isNumber(messageData)
@@ -875,8 +872,7 @@ class NylasEnvConstructor extends Model
     else
       throw new Error("Must pass a valid message to show dialog", message)
 
-    dialog = remote.require('dialog')
-    dialog.showMessageBox null, {
+    remote.dialog.showMessageBox null, {
       type: 'warning'
       buttons: ['Okay'],
       message: title

--- a/src/package-manager.coffee
+++ b/src/package-manager.coffee
@@ -1,6 +1,7 @@
 path = require 'path'
 
 _ = require 'underscore'
+{remote} = require 'electron'
 EmitterMixin = require('emissary').Emitter
 {Emitter} = require 'event-kit'
 fs = require 'fs-plus'
@@ -336,9 +337,6 @@ class PackageManager
     packages
 
   installPackageFromPath: (packageSourceDir, callback) ->
-    dialog = require('remote').require('dialog')
-    shell = require('shell')
-
     return unless @verifyValidPackage(packageSourceDir, callback)
 
     packagesDir = path.join(NylasEnv.getConfigDirPath(), 'packages')
@@ -352,7 +350,7 @@ class PackageManager
         if packageAlreadyExists
           message = "A package named '#{packageName}' is already installed
                  in ~/.nylas/packages."
-          dialog.showMessageBox({
+          remote.dialog.showMessageBox({
             type: 'warning'
             buttons: ['OK']
             title: 'Package already installed'
@@ -367,7 +365,7 @@ class PackageManager
         apm = new APMWrapper()
         apm.installDependenciesInPackageDirectory packageTargetDir, (err) =>
           if err
-            dialog.showMessageBox({
+            remote.dialog.showMessageBox({
               type: 'warning'
               buttons: ['OK']
               title: 'Package installation failed'
@@ -385,8 +383,7 @@ class PackageManager
     else
       errMsg = "The folder you selected doesn't look like a valid N1 plugin. All N1 plugins must have a package.json file in the top level of the folder. Check the contents of #{packageSourceDir} and try again"
 
-      dialog = require('remote').require('dialog')
-      dialog.showMessageBox({
+      remote.dialog.showMessageBox({
         type: 'warning'
         buttons: ['OK']
         title: 'Not a valid plugin folder'

--- a/src/sheet-toolbar.cjsx
+++ b/src/sheet-toolbar.cjsx
@@ -3,6 +3,7 @@ Sheet = require './sheet'
 Flexbox = require './components/flexbox'
 RetinaImg = require './components/retina-img'
 Utils = require './flux/models/utils'
+{remote} = require 'electron'
 _str = require 'underscore.string'
 _ = require 'underscore'
 
@@ -111,7 +112,7 @@ class ToolbarMenuControl extends React.Component
     </div>
 
   _openMenu: =>
-    applicationMenu = require('remote').getGlobal('application').applicationMenu
+    applicationMenu = remote.getGlobal('application').applicationMenu
     applicationMenu.menu.popup(NylasEnv.getCurrentWindow())
 
 ComponentRegistry.register ToolbarWindowControls,


### PR DESCRIPTION
I was inspired by atom/atom#9627 to implement similar changes to N1. I did a simple grep to find cases of `dialog` used by the renderer and main processes and then converted them to the newer style. The specs were updated as well to account for these new changes.