### PR TITLE
fix(imports): switch to Electron's require('electron')

### DIFF
--- a/internal_packages/composer-templates/spec/template-store-spec.es6
+++ b/internal_packages/composer-templates/spec/template-store-spec.es6
@@ -1,7 +1,9 @@
 import fs from 'fs';
-import shell from 'shell';
+import { remote } from 'electron';
 import {Message, DraftStore} from 'nylas-exports';
 import TemplateStore from '../lib/template-store';
+
+const { shell } = remote;
 
 const stubTemplatesDir = '~/.nylas/templates';
 

--- a/internal_packages/preferences/lib/tabs/preferences-keymaps.jsx
+++ b/internal_packages/preferences/lib/tabs/preferences-keymaps.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import _ from 'underscore';
 import path from 'path';
 import fs from 'fs';
-import shell from 'shell';
+import { remote } from 'electron';
 
-import {Flexbox} from 'nylas-component-kit';
+import { Flexbox } from 'nylas-component-kit';
+
+const { shell } = remote;
 
 const displayedKeybindings = [
   {

--- a/src/flux/stores/database-store.coffee
+++ b/src/flux/stores/database-store.coffee
@@ -14,7 +14,7 @@ DatabaseSetupQueryBuilder = require './database-setup-query-builder'
 DatabaseChangeRecord = require './database-change-record'
 DatabaseTransaction = require './database-transaction'
 
-{ipcRenderer} = require 'electron'
+{remote, ipcRenderer} = require 'electron'
 
 DatabaseVersion = 22
 DatabasePhase =
@@ -107,7 +107,7 @@ class DatabaseStore extends NylasStore
   _onPhaseChange: (event) =>
     return if NylasEnv.inSpecMode()
 
-    app = require('remote').getGlobal('application')
+    app = remote.getGlobal('application')
     phase = app.databasePhase()
 
     if phase is DatabasePhase.Setup and NylasEnv.isWorkWindow()
@@ -133,7 +133,7 @@ class DatabaseStore extends NylasStore
   # extremely frequently as new models are added when packages load.
   refreshDatabaseSchema: ->
     return unless NylasEnv.isWorkWindow()
-    app = require('remote').getGlobal('application')
+    app = remote.getGlobal('application')
     phase = app.databasePhase()
     if phase isnt DatabasePhase.Setup
       app.setDatabasePhase(DatabasePhase.Setup)

--- a/static/index.js
+++ b/static/index.js
@@ -9,6 +9,9 @@ window.eval = global.eval = function() {
 
 var path = require('path');
 
+var electron = require('electron');
+var remote = electron.remote;
+
 function setLoadTime (loadTime) {
   if (global.NylasEnv) {
     global.NylasEnv.loadTime = loadTime
@@ -17,7 +20,7 @@ function setLoadTime (loadTime) {
 }
 
 function handleSetupError (error) {
-  var currentWindow = require('remote').getCurrentWindow()
+  var currentWindow = remote.getCurrentWindow()
   currentWindow.setSize(800, 600)
   currentWindow.center()
   currentWindow.show()


### PR DESCRIPTION
Electron in 0.37.5 phases out the usage of `require('built-in-module')` in favor of `require('electron').builtInModule`. This commit corrects usage in some cases that cause N1 to not start under Electron 0.37.5.