### PR TITLE
Expose 'react-addons-test-utils' for spec testing external plugins

### DIFF
--- a/src/global/nylas-exports.coffee
+++ b/src/global/nylas-exports.coffee
@@ -158,6 +158,7 @@ class NylasExports
   # Libraries
   @get "React", -> require 'react' # Our version of React for 3rd party use
   @get "ReactDOM", -> require 'react-dom'
+  @get "ReactTestUtils", -> require 'react-addons-test-utils'
   @get "Reflux", -> require 'reflux'
   @get "Rx", -> require 'rx-lite'
   @get "Keytar", -> require 'keytar' # atom-keytar access through native module


### PR DESCRIPTION
In Cypher, I use `ReactTestUtils` and was exposed as `React.addons.ReactTestUtils` in React 0.13, but no longer in React 0.14. To run spec tests properly, Cypher needs `ReactTestUtils` exposed.

This PR exposes it through `nylas-exports`, but it has the side-effect of exposing it while not in dev mode. If there is a better way to expose this during spec mode, please feel free to comment.