### PR TITLE
`nylas-env-spec` handle remote method calls through `electron.remote`

### DIFF
--- a/spec/nylas-env-spec.coffee
+++ b/spec/nylas-env-spec.coffee
@@ -1,5 +1,6 @@
 {$, $$}  = require '../src/space-pen-extensions'
 Exec = require('child_process').exec
+{remote} = require 'electron'
 path = require 'path'
 Package = require '../src/package'
 ThemeManager = require '../src/theme-manager'
@@ -44,34 +45,32 @@ describe "the `NylasEnv` global", ->
         expect(actualWidth).toBe inputMinWidth
 
     describe '::getDefaultWindowDimensions', ->
-      screen = require('remote').require 'screen'
-
       it "returns primary display's work area size if it's small enough", ->
-        spyOn(screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1440, height: 900
+        spyOn(remote.screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1440, height: 900
 
         out = NylasEnv.getDefaultWindowDimensions()
         expect(out).toEqual x: 0, y: 0, width: 1440, height: 900
 
       it "caps width at 1440 and centers it, if wider", ->
-        spyOn(screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1840, height: 900
+        spyOn(remote.screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1840, height: 900
 
         out = NylasEnv.getDefaultWindowDimensions()
         expect(out).toEqual x: 200, y: 0, width: 1440, height: 900
 
       it "caps height at 900 and centers it, if taller", ->
-        spyOn(screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1440, height: 1100
+        spyOn(remote.screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1440, height: 1100
 
         out = NylasEnv.getDefaultWindowDimensions()
         expect(out).toEqual x: 0, y: 100, width: 1440, height: 900
 
       it "returns only the max viewport size if it's smaller than the defaults", ->
-        spyOn(screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1000, height: 800
+        spyOn(remote.screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1000, height: 800
 
         out = NylasEnv.getDefaultWindowDimensions()
         expect(out).toEqual x: 0, y: 0, width: 1000, height: 800
 
       it "always rounds X and Y", ->
-        spyOn(screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1845, height: 955
+        spyOn(remote.screen, 'getPrimaryDisplay').andReturn workAreaSize: width: 1845, height: 955
 
         out = NylasEnv.getDefaultWindowDimensions()
         expect(out).toEqual x: 202, y: 27, width: 1440, height: 900
@@ -95,8 +94,7 @@ describe "the `NylasEnv` global", ->
       updateAvailableHandler = jasmine.createSpy("update-available-handler")
       subscription = NylasEnv.onUpdateAvailable updateAvailableHandler
 
-      autoUpdater = require('remote').require('auto-updater')
-      autoUpdater.emit 'update-downloaded', null, "notes", "version"
+      remote.autoUpdater.emit 'update-downloaded', null, "notes", "version"
 
       waitsFor ->
         updateAvailableHandler.callCount > 0


### PR DESCRIPTION
This PR fixes the rather cryptic error during https://travis-ci.org/nylas/N1/jobs/122675741. I experienced a lot of these trying to work patch up N1 to work under Electron 0.37.