### PR TITLE
Removed the link to the repository as it is a 404

### DIFF
--- a/docs/GettingStarted.html
+++ b/docs/GettingStarted.html
@@ -384,8 +384,3 @@ edit_url: "https://github.com/nylas/N1/blob/master/docs/index.md"
   the user. Passing this data back to the UI component follows exactly the same pattern as the barebones data shown
   above, so we&#39;ll leave it as an exercise for  the reader. :)
 </p>
-<blockquote>
-  <p>
-    You can find a more extensive version of this example in our <a href="https://github.com/nylas/edgehill-plugins/tree/master/sidebar-github-profile">sample plugins repository</a>.
-  </p>
-</blockquote>


### PR DESCRIPTION
https://github.com/nylas/edgehill-plugins/tree/master/sidebar-github-profile Is no longer a repository. Does anyone know a new one to add it, or should this section be removed (it seems a shame for them to go).