### PR TITLE
Fix Github Sidebar Plugin

### DIFF
--- a/internal_packages/github-contact-card/lib/github-user-store.es6
+++ b/internal_packages/github-contact-card/lib/github-user-store.es6
@@ -80,9 +80,9 @@ class GithubUserStore extends NylasStore {
       // repositories.
       if (profile !== false) {
         profile.repos = [];
-        this._githubRequest(profile.repos_url, (reposErr, reposResp, repos)=> {
+        this._githubRequest(`https://api.github.com/search/repositories?q=user:${profile.login}&sort=stars&order=desc`, (reposErr, reposResp, data)=> {
           // Sort the repositories by their stars (`-` for descending order)
-          profile.repos = _.sortBy(repos, (repo)=> -repo.stargazers_count);
+          profile.repos = _.sortBy(data.items, (repo)=> -repo.stargazers_count);
           // Trigger so that our React components refresh their state and display
           // the updated data.
           this.trigger(this);


### PR DESCRIPTION
Hopefully fixes #1991

I don't have N1 setup locally, so this is a blind shot–would appreciate somebody who has it set up to pull this and verify this fixes the issue, but as far as I can tell it should.

The gist is:

> Looking at the code, what you do is use the `search/users` endpoint to find users by email and taking the repos from there. You then load the repositories of the username, but we can't sort those by most-starred: "sort string Can be one of `created`, `updated`, `pushed`, `full_name`. Default: `full_name`" *([src](https://developer.github.com/v3/repos/#list-user-repositories))*
> What we could instead do is use the search API, which **allows us to search for repositories by a specific user and sort by most starred**. This is a tiny bit hacky, but works perfectly fine. E.g. this is the URL for my most starred repos: `https://api.github.com/search/repositories?q=user:mxstbr&sort=stars&order=desc`