### PR TITLE
Doing write on a GET is invalid.

### DIFF
--- a/internal_packages/worker-sync/lib/nylas-long-connection.coffee
+++ b/internal_packages/worker-sync/lib/nylas-long-connection.coffee
@@ -135,7 +135,7 @@ class NylasLongConnection
         socket.on 'connect', =>
           @setStatus(NylasLongConnection.Status.Connected)
           @closeIfDataStops()
-      @_req.write("1")
+      @_req.end()
 
 
   close: ->

--- a/src/flux/nylas-long-connection.es6
+++ b/src/flux/nylas-long-connection.es6
@@ -151,7 +151,7 @@ class NylasLongConnection {
         this.closeIfDataStops()
       })
     })
-    this._req.write("1")
+    this._req.end()
     return this
   }
 


### PR DESCRIPTION
Ending the request sends it to the server (without an invalid GET data body).

Tested with 0.4.19 and 0.4.25.