### PR TITLE
Parse Office 365 names

### DIFF
--- a/internal_packages/message-list/lib/message-participants.cjsx
+++ b/internal_packages/message-list/lib/message-participants.cjsx
@@ -58,7 +58,7 @@ class MessageParticipants extends React.Component
       if c.name?.length > 0 and c.name isnt c.email
         <div key={"#{c.email}-#{i}"} className="participant selectable">
           <div className="participant-primary" onClick={@_selectText}>
-            {c.name}
+            {c.fullName()}
           </div>
           <div className="participant-secondary">
             {"<"}<span onClick={@_selectText}>{c.email}</span>{">#{comma}"}

--- a/spec/models/contact-spec.coffee
+++ b/spec/models/contact-spec.coffee
@@ -116,6 +116,22 @@ describe "Contact", ->
     expect(c8.firstName()).toBe "Mike"
     expect(c8.lastName()).toBe "K@ylor"
 
+  it "properly parses names with last, first (description)", ->
+    c1 = new Contact {name: "Smith, Bob"}
+    expect(c1.firstName()).toBe "Bob"
+    expect(c1.lastName()).toBe "Smith"
+    expect(c1.fullName()).toBe "Bob Smith"
+
+    c2 = new Contact {name: "von Smith, Ricky Bobby"}
+    expect(c2.firstName()).toBe "Ricky Bobby"
+    expect(c2.lastName()).toBe "von Smith"
+    expect(c2.fullName()).toBe "Ricky Bobby von Smith"
+
+    c3 = new Contact {name: "von Smith, Ricky Bobby (Awesome Employee)"}
+    expect(c3.firstName()).toBe "Ricky Bobby"
+    expect(c3.lastName()).toBe "von Smith (Awesome Employee)"
+    expect(c3.fullName()).toBe "Ricky Bobby von Smith (Awesome Employee)"
+
   it "should properly return `You` as the display name for the current user", ->
     c1 = new Contact {name: " Test Monkey", email: @account.emailAddress}
     expect(c1.displayName()).toBe "You"

--- a/src/flux/models/contact.coffee
+++ b/src/flux/models/contact.coffee
@@ -165,18 +165,34 @@ class Contact extends Model
     # Take care of whitespace
     name = name.trim()
 
+    # Handle last name, first name
+    parts = @_parseReverseNames(name)
+
     # Split the name into words and remove parts that are prefixes and suffixes
-    parts = []
-    parts = name.split(/\s+/)
-    parts = _.reject parts, (part) ->
-      part = part.toLowerCase().replace(/\./,'')
-      (part of name_prefixes) or (part of name_suffixes)
+    if parts.join('').length == 0
+      parts = []
+      parts = name.split(/\s+/)
+      parts = _.reject parts, (part) ->
+        part = part.toLowerCase().replace(/\./,'')
+        (part of name_prefixes) or (part of name_suffixes)
 
     # If we've removed all the parts, just return the whole name
     parts = [name] if parts.join('').length == 0
 
     # If all that failed, fall back to email
     parts = [@email] if parts.join('').length == 0
+
+    parts
+
+  _parseReverseNames: (name) ->
+    parts = []
+    [lastName, firstName] = name.split(',')
+    if firstName
+      [firstName, description] = firstName.split('(')
+
+      parts.push(firstName.trim())
+      parts.push(lastName.trim())
+      parts.push("(" + description.trim()) if description
 
     parts
 


### PR DESCRIPTION
Office 365 likes to format email addresses as follows:
Last Name, First Name (Some Description) <email@address.org>

This causes Contact.firstName() (and hence sometimes displayName()) to return
"Last Name," which looks a bit odd in the message/thread views.

The intent of the commit is to correctly parse these names so that (using the
above example):
- firstName = "First Name"
- lastName = "Last Name (Some Description)"
- fullName = "First Name Last Name (Some Description)"

These behavioral changes only impact names containing a ','.

I don't know that this really provides exhaustive coverage of Office 365, and
keeping the description as part of the last name is not completely guilt free,
but it's not any worse than the previous state of affairs which also has
the description in the same field but combined instead with (misplaced)
first name data.