### PR TITLE
horizontal scrollbar does not appear when viewing wide email

### DIFF
--- a/internal_packages/message-list/lib/email-frame.jsx
+++ b/internal_packages/message-list/lib/email-frame.jsx
@@ -82,13 +82,18 @@ export default class EmailFrame extends React.Component {
   }
 
   _getFrameHeight = (doc) => {
+    let height = 0;
+
     if (doc && doc.body) {
-      return doc.body.scrollHeight;
+      height = doc.body.scrollHeight;
     }
+
     if (doc && doc.documentElement) {
-      return doc.documentElement.scrollHeight;
+      height = doc.documentElement.scrollHeight;
     }
-    return 0;
+
+    // scrollHeight does not include space required by scrollbar
+    return height + 25;
   }
 
   _setFrameHeight = () => {

--- a/static/email-frame.less
+++ b/static/email-frame.less
@@ -57,6 +57,7 @@
     border: 0;
     margin: 0;
     padding: 0;
+    overflow-x: auto;
 
     -webkit-text-size-adjust: auto;
     word-wrap: break-word; -webkit-nbsp-mode: space; -webkit-line-break: after-white-space;


### PR DESCRIPTION
This fixes issue #1128 

The horizontal scrollbar was not showing up in two cases for me:
1) A badly formatted email had some weird span with white-space: nowrap which caused the words to run off the screen
2) A wide image was only showing the left part.

Either case, the problem is the iframe not scrolling horizontally. I fiddled with the iframe for a while and couldn't get it to scroll, so I ended up setting overflow on the body of the iframe page instead.

**Before:**
![selection](https://cloud.githubusercontent.com/assets/7494573/14730958/e8544fce-0819-11e6-8a78-369bc7052700.png)

**After (notice border to the right):**
![selection](https://cloud.githubusercontent.com/assets/7494573/14730946/ada08e60-0819-11e6-908b-7e81de08d023.png)