### PR TITLE
Update title for system tray

### DIFF
--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -12,7 +12,7 @@ module.exports =
           systemTray:
             type: 'boolean'
             default: true
-            title: "Show icon in menu bar"
+            title: "Show icon in menu bar / system tray"
             platforms: ['darwin', 'linux']
           showImportant:
             type: 'boolean'


### PR DESCRIPTION
Using only "Menu Bar" confuses Linux users because ''Menu Bar'' word is only used withing Mac OS. So, also use "System Tray" word.