### PR TITLE
Show under Internet Category in Linux 

### DIFF
--- a/build/resources/linux/nylas.desktop.in
+++ b/build/resources/linux/nylas.desktop.in
@@ -7,5 +7,5 @@ Icon=<%= iconName %>
 Type=Application
 StartupNotify=true
 StartupWMClass=Nylas N1
-Categories=GNOME;GTK;Email;Utility;Development;
+Categories=GNOME;GTK;Network;Email;Utility;Development;
 MimeType=text/plain;x-scheme-handler/mailto;x-scheme-handler/nylas;

--- a/src/config-schema.coffee
+++ b/src/config-schema.coffee
@@ -12,7 +12,7 @@ module.exports =
           systemTray:
             type: 'boolean'
             default: true
-            title: "Show icon in menu bar"
+            title: "Show icon in menu bar / system tray"
             platforms: ['darwin', 'linux']
           showImportant:
             type: 'boolean'


### PR DESCRIPTION
Right now, N1 is showing under Programming Category. "Network" should be added to show under Internet Category.