### PR TITLE
Removed unneeded twitter:app meta data

### DIFF
--- a/_includes/top.html
+++ b/_includes/top.html
@@ -13,15 +13,6 @@
   <meta name="twitter:creator" content="@nylas_crew">
   <meta name="twitter:image:src" content="https://nylas.com/N1/images/meta_share.png?feb2016">
   <meta name="twitter:domain" content="nylas.com">
-  <meta name="twitter:app:name:iphone" content="">
-  <meta name="twitter:app:name:ipad" content="">
-  <meta name="twitter:app:name:googleplay" content="">
-  <meta name="twitter:app:url:iphone" content="">
-  <meta name="twitter:app:url:ipad" content="">
-  <meta name="twitter:app:url:googleplay" content="">
-  <meta name="twitter:app:id:iphone" content="">
-  <meta name="twitter:app:id:ipad" content="">
-  <meta name="twitter:app:id:googleplay" content="">
 
   <meta property="og:title" content="{{ page.title }}"/>
   <meta property="og:description" content="N1 is a new mail client for Mac, Linux and Windows, built on the modern web and designed to be extended."/>


### PR DESCRIPTION
Removed unneeded twitter:app meta data - those are only needed for sites which have native apps available on Google Play and iOS App Store.