### PR TITLE
fixed bug timezone cannot detect in fedora

### DIFF
--- a/build/resources/linux/redhat/nylas.spec.in
+++ b/build/resources/linux/redhat/nylas.spec.in
@@ -6,7 +6,7 @@ License:        GPLv3
 URL:            https://nylas.com/N1
 AutoReqProv:    no # Avoid libchromiumcontent.so missing dependency
 
-requires:       libgnome-keyring0, gir1.2-gnomekeyring-1.0
+requires:       libgnome-keyring
 
 %description
 <%= description %>

--- a/src/flux/models/utils.coffee
+++ b/src/flux/models/utils.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore'
 fs = require('fs-plus')
 path = require('path')
 moment = require('moment-timezone')
-tz = Intl.DateTimeFormat().resolvedOptions().timeZone ? Intl.DateTimeFormat().resolvedOptions().timeZone || moment.tz.guess()
+tz = Intl.DateTimeFormat().resolvedOptions().timeZone ? moment.tz.guess()
 
 DefaultResourcePath = null
 TaskRegistry = require('../../task-registry').default

--- a/src/flux/models/utils.coffee
+++ b/src/flux/models/utils.coffee
@@ -2,7 +2,7 @@ _ = require 'underscore'
 fs = require('fs-plus')
 path = require('path')
 moment = require('moment-timezone')
-tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+tz = Intl.DateTimeFormat().resolvedOptions().timeZone ? Intl.DateTimeFormat().resolvedOptions().timeZone || moment.tz.guess()
 
 DefaultResourcePath = null
 TaskRegistry = require('../../task-registry').default


### PR DESCRIPTION
Hi,
I was found the problem in Linux, the browser cannot detect timezone by function Inlt so I used moment.tz.guess() function to get timezone.