### PR TITLE
Don't show phishing warning if Reply-To and From are on the same domain; even with differing subdomain

### DIFF
--- a/internal_packages/phishing-detection/lib/main.jsx
+++ b/internal_packages/phishing-detection/lib/main.jsx
@@ -7,6 +7,8 @@ import {
   MessageStore,
 } from 'nylas-exports';
 
+const tld = require('tld');
+
 // Notice that this file is `main.cjsx` rather than `main.coffee`. We use the
 // `.cjsx` filetype because we use the CJSX DSL to describe markup for React to
 // render. Without the CJSX, we could just name this file `main.coffee` instead.
@@ -49,9 +51,9 @@ class PhishingIndicator extends React.Component {
     // `Message` models from `MessageStore`.
     if (message && message.replyTo && message.replyTo.length !== 0) {
       const from = message.from[0].email
-      const fromDomain = from.split('@')[1];
+      const fromDomain = tld.registered(from.split('@')[1]);
       const replyTo = message.replyTo[0].email
-      const replyToDomain = replyTo.split('@')[1];
+      const replyToDomain = tld.registered(replyTo.split('@')[1]);
       if (replyToDomain !== fromDomain) {
         return (
           <div className="phishingIndicator">

--- a/internal_packages/phishing-detection/package.json
+++ b/internal_packages/phishing-detection/package.json
@@ -17,5 +17,6 @@
     "composer": true
   },
   "dependencies": {
+    "tld": "^0.0.2"
   }
 }


### PR DESCRIPTION
This commit improves on nylas/N1#2343 (which allowed From and
Reply-To to be different aliases @ the same domain) by allowing the
address to differ by a subdomain.

For example, the pairs:

    From:     foo@bar.com
    Reply-To: foo@sub.bar.com

    From:     foo@bar.co.uk
    Reply-To: foo@other.bar.co.uk

    From:     foo@bar.com
    Reply-To: foobar@bar.com
are each now allowed without warning.