### PR TITLE
Make display of onboarding page conditional.

### DIFF
--- a/src/browser/application.es6
+++ b/src/browser/application.es6
@@ -193,8 +193,11 @@ export default class Application extends EventEmitter {
     const accounts = this.config.get('nylas.accounts');
     const hasAccount = accounts && accounts.length > 0;
     const hasN1ID = this.config.get('nylas.identity.id');
+    const env = this.config.get('env');
+    const isLocalOrCustom = (env === 'local' || env === 'custom');
 
-    if (hasAccount && hasN1ID) {
+
+    if (isLocalOrCustom || (hasAccount && hasN1ID)) {
       this.windowManager.ensureWindow(WindowManager.MAIN_WINDOW);
       this.windowManager.ensureWindow(WindowManager.WORK_WINDOW);
     } else {


### PR DESCRIPTION
When running against a custom Sync Engine, viewing the onboarding page
on startup does not make much sense. This here adds code that checks for
the `env` of the Nylas config and skips the onboarding if it is `local`
or `custom`.

This fixes #2468.