### PR TITLE
Change pending unread notification stack to be a queue

### DIFF
--- a/internal_packages/unread-notifications/spec/main-spec.es6
+++ b/internal_packages/unread-notifications/spec/main-spec.es6
@@ -52,21 +52,21 @@ describe("UnreadNotifications", function UnreadNotifications() {
       unread: true,
       date: new Date(),
       from: [new Contact({name: 'Ben', email: 'benthis.example.com'})],
-      subject: "Hello World",
+      subject: "Hello World 3",
       threadId: "A",
     });
     this.msg4 = new Message({
       unread: true,
       date: new Date(),
       from: [new Contact({name: 'Ben', email: 'benthis.example.com'})],
-      subject: "Hello World",
+      subject: "Hello World 4",
       threadId: "A",
     });
     this.msg5 = new Message({
       unread: true,
       date: new Date(),
       from: [new Contact({name: 'Ben', email: 'benthis.example.com'})],
-      subject: "Hello World",
+      subject: "Hello World 5",
       threadId: "A",
     });
     this.msgUnreadButArchived = new Message({
@@ -154,6 +154,27 @@ describe("UnreadNotifications", function UnreadNotifications() {
         advanceClock(2000)
         advanceClock(2000)
         expect(NativeNotifications.displayNotification.callCount).toEqual(3)
+      });
+    });
+  });
+
+  it("should create Notifications in the order of messages received", () => {
+    waitsForPromise(() => {
+      return this.notifier._onNewMailReceived({message: [this.msg1, this.msg2]})
+      .then(() => {
+        advanceClock(2000);
+        return this.notifier._onNewMailReceived({message: [this.msg3, this.msg4]});
+      })
+      .then(() => {
+        advanceClock(2000);
+        advanceClock(2000);
+        expect(NativeNotifications.displayNotification.callCount).toEqual(4);
+        const subjects = NativeNotifications.displayNotification.calls.map((call) => {
+          return call.args[0].subtitle;
+        });
+        const expected = [this.msg1, this.msg2, this.msg3, this.msg4]
+          .map((msg) => msg.subject);
+        expect(subjects).toEqual(expected);
       });
     });
   });

--- a/internal_packages/unread-notifications/spec/main-spec.es6
+++ b/internal_packages/unread-notifications/spec/main-spec.es6
@@ -226,7 +226,7 @@ describe("UnreadNotifications", function UnreadNotifications() {
     });
   });
 
-  it("should not create a Notification if the new messages are not unread", () => {
+  it("should not create a Notification if the new messages are read", () => {
     waitsForPromise(() => {
       return this.notifier._onNewMailReceived({message: [this.msgRead]})
       .then(() => {


### PR DESCRIPTION
Relatively minor, but I noticed it while poking around in the file, and
it started to bother me.

Consider the case where a user launches N1, and has 3 unreads since
their last launch. Additionally, after N1 has launched, they begin
receiving a new mail every 2 seconds.

Current behavior would be a notification for 1 of the 3 unread emails,
then every 2 seconds a notification for the most recently received mail.
They would only finally receive notifications for the other 2 original
messages once they stopped getting new mail.