### PR TITLE
Clear notifications when emails are read

### DIFF
--- a/internal_packages/unread-notifications/lib/main.es6
+++ b/internal_packages/unread-notifications/lib/main.es6
@@ -14,11 +14,29 @@ export class Notifier {
     this.activationTime = Date.now();
     this.stack = [];
     this.stackProcessTimer = null;
+
+    this.activeNotifications = {};
+    this.unlisteners.push(DatabaseStore.listen(this._onDatabaseUpdated, this));
   }
 
   unlisten() {
     for (const unlisten of this.unlisteners) {
       unlisten();
+    }
+  }
+
+  _onDatabaseUpdated({objectClass, objects}) {
+    if (objectClass === 'Thread') {
+      objects
+        .filter((thread) => !thread.unread)
+        .forEach((thread) => this._onThreadIsRead(thread));
+    }
+  }
+
+  _onThreadIsRead({id: threadId}) {
+    if (threadId in this.activeNotifications) {
+      this.activeNotifications[threadId].forEach((n) => n.close());
+      delete this.activeNotifications[threadId];
     }
   }
 
@@ -43,7 +61,7 @@ export class Notifier {
       body = null
     }
 
-    NativeNotifications.displayNotification({
+    const notification = NativeNotifications.displayNotification({
       title: title,
       subtitle: subtitle,
       body: body,
@@ -63,6 +81,12 @@ export class Notifier {
         });
       },
     });
+
+    if (!this.activeNotifications[thread.id]) {
+      this.activeNotifications[thread.id] = [notification];
+    } else {
+      this.activeNotifications[thread.id].push(notification);
+    }
   }
 
   _notifyMessages() {

--- a/internal_packages/unread-notifications/spec/main-spec.es6
+++ b/internal_packages/unread-notifications/spec/main-spec.es6
@@ -21,9 +21,11 @@ describe("UnreadNotifications", function UnreadNotifications() {
     const account = AccountStore.accounts()[0];
 
     this.threadA = new Thread({
+      id: 'A',
       categories: [inbox],
     });
     this.threadB = new Thread({
+      id: 'B',
       categories: [archive],
     });
 
@@ -108,7 +110,9 @@ describe("UnreadNotifications", function UnreadNotifications() {
       return Promise.resolve(null);
     });
 
-    spyOn(NativeNotifications, 'displayNotification').andCallFake(() => false)
+    this.notification = jasmine.createSpyObj('notification', ['close']);
+    spyOn(NativeNotifications, 'displayNotification').andReturn(this.notification);
+
     spyOn(Promise, 'props').andCallFake((dict) => {
       const dictOut = {};
       for (const key of Object.keys(dict)) {
@@ -251,6 +255,27 @@ describe("UnreadNotifications", function UnreadNotifications() {
         expect(NativeNotifications.displayNotification).not.toHaveBeenCalled()
       });
     });
+  });
+
+  it("clears notifications when a thread is read", () => {
+    waitsForPromise(() => {
+      return this.notifier._onNewMailReceived({message: [this.msg1]})
+      .then(() => {
+        expect(NativeNotifications.displayNotification).toHaveBeenCalled();
+        expect(this.notification.close).not.toHaveBeenCalled();
+        this.notifier._onThreadIsRead(this.threadA);
+        expect(this.notification.close).toHaveBeenCalled();
+      });
+    });
+  });
+
+  it("detects changes that may be a thread being read", () => {
+    const unreadThread = { unread: true };
+    const readThread = { unread: false };
+    spyOn(this.notifier, '_onThreadIsRead');
+    this.notifier._onDatabaseUpdated({ objectClass: 'Thread', objects: [unreadThread, readThread]});
+    expect(this.notifier._onThreadIsRead.calls.length).toEqual(1);
+    expect(this.notifier._onThreadIsRead).toHaveBeenCalledWith(readThread);
   });
 
   it("should play a sound when it gets new mail", () => {

--- a/src/native-notifications.coffee
+++ b/src/native-notifications.coffee
@@ -9,5 +9,6 @@ class NativeNotifications
       tag: tag
     })
     n.onclick = onActivate
+    n
 
 module.exports = new NativeNotifications


### PR DESCRIPTION
Fixes #1393

The objects returned by `new Notification()` have  a `.close()` method.
So we can just keep a list of notifications that have been sent, and
close them when that message has been read.