### PR TITLE
Fix failing clean script

### DIFF
--- a/script/clean
+++ b/script/clean
@@ -12,7 +12,7 @@ var home = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
 var tmpdir = os.tmpdir();
 
 // Windows: Use START as a way to ignore error if nylas.exe isnt running
-var killnylas = process.platform === 'win32' ? 'START taskkill /F /IM ' + productName + '.exe' : 'pkill -9 ' + productName + ' || true';
+var killnylas = process.platform === 'win32' ? 'START taskkill /F /IM "' + productName + '.exe"' : 'pkill -9 "' + productName + '" || true';
 
 var commands = [
   killnylas,


### PR DESCRIPTION
The clean script fails since productName is "Nylas N1" which contains a space and it appears to pkill 2 patterns. This is causing the script to stop in my linux machine. Now the productName is wrapped with quotes to prevent this from happening.