### PR TITLE
Fix incorrect port number when using https

### DIFF
--- a/internal_packages/worker-sync/lib/nylas-long-connection.coffee
+++ b/internal_packages/worker-sync/lib/nylas-long-connection.coffee
@@ -103,7 +103,6 @@ class NylasLongConnection
       if @_api.APIRoot.indexOf('https') is -1
         lib = require 'http'
       else
-        options.port = 443
         lib = require 'https'
 
       @_req = lib.request options, (res) =>


### PR DESCRIPTION
When APIRoot is using https, the port will forced to be 443 even when APIRoot
indicates another port. This is because of the line options.port = 443
overwriting the correct options.port extracted by url.parse. This is fixed by
removing the problematic line. The default port is still 443 if you look into
https.js. In case we want a different default port in the future, we can do
options.port = options.port || 443.