### PR TITLE
Pasting into a participant field now preserves any text already there (Issue #2410)

### DIFF
--- a/src/components/tokenizing-text-field.cjsx
+++ b/src/components/tokenizing-text-field.cjsx
@@ -528,8 +528,13 @@ class TokenizingTextField extends React.Component
 
   _onPaste: (event) =>
     data = event.clipboardData.getData('text/plain')
-    @_addInputValue(data)
-    event.preventDefault()
+    newInputValue = @state.inputValue + data
+    if RegExpUtils.emailRegex().test(newInputValue)
+      @_addInputValue(newInputValue, skipNameLookup: true)
+      event.preventDefault()
+    else
+      @_refreshCompletions(newInputValue)
+
 
   # Managing Suggestions
 


### PR DESCRIPTION
This modifies the behavious when pasting into the to, cc or bcc fields of a new draft. This allows you to, for example, copy the domain of the email address from the clipboard and type the addressee and then paste the domain. Any text already in the input field is not automatically deleted. Rather the pasted
text is added to the already existing text. If the new contents of the email field now matches as an email address (based on RegExpUtils.emailRegex().test()), then the address is immediately tokenized. If the new input text doesn't match as an email, just append the new text and wait for further input.