### PR TITLE
Small fix to re-enable tests when running ./N1 --test

### DIFF
--- a/spec/stores/draft-helpers-spec.es6
+++ b/spec/stores/draft-helpers-spec.es6
@@ -34,7 +34,7 @@ describe('DraftHelpers', function describeBlock() {
     });
   });
 
-  fdescribe('shouldAppendQuotedText', () => {
+  describe('shouldAppendQuotedText', () => {
     it('returns true if message is reply and has no marker', () => {
       const draft = {
         replyToMessageId: 1,


### PR DESCRIPTION
A previous commit (ad04775) added an fdescribe() to one of the tests in
draft-helpers-spec. This changes that to a regular describe() so that
all tests will be run when running ./N1 --test.