### PR TITLE
Adding nowrap to outline-view item names 

### DIFF
--- a/static/components/outline-view.less
+++ b/static/components/outline-view.less
@@ -99,6 +99,7 @@
       overflow: hidden;
       line-height: @line-height-small;
       text-overflow: ellipsis;
+      white-space: nowrap;
     }
     .item-count-box {
       order: 3;


### PR DESCRIPTION
to prevent email address with hyphens from wrapping.

Currently:
![Before](https://www.dropbox.com/s/65y82zbsz4ncywl/Screenshot%202016-08-11%2011.12.48.png?raw=1)

After adding nowrap:
![After](https://www.dropbox.com/s/9snm1yx4o0ii6i8/Screenshot%202016-08-11%2011.13.21.png?raw=1)

