### PR TITLE
improve first name parser by adding honorific exclusions

### DIFF
--- a/src/flux/models/contact.coffee
+++ b/src/flux/models/contact.coffee
@@ -146,9 +146,9 @@ class Contact extends Model
     return @_nameParts().join(' ')
 
   firstName: ->
-    articles = ['a', 'the']
+    exclusions = ['a', 'the', 'dr.', 'mrs.', 'mr.', 'mx.', 'prof.', 'ph.d.']
     for part in @_nameParts()
-      if part.toLowerCase() not in articles
+      if part.toLowerCase() not in exclusions
         return part
     return ""
 


### PR DESCRIPTION
added exclusions for Dr., Mrs., Mr., Mx., Prof., and Ph.D. in the `firstName` method of `contact.coffee` so that their first name would not show up in emails as such