### PR TITLE
Closes #2723 -> apm ignore plugin dev-dependencies

### DIFF
--- a/src/apm-wrapper.coffee
+++ b/src/apm-wrapper.coffee
@@ -219,7 +219,7 @@ class APMWrapper
         error.stderr = stderr
         callback(error)
 
-    apmProcess = @runCommand(['install'], {cwd: dir}, exit)
+    apmProcess = @runCommand(['install', '--production'], {cwd: dir}, exit)
     handleProcessErrors(apmProcess, errorMessage, callback)
 
   uninstall: (pack, callback) ->


### PR DESCRIPTION
Adds the `--production` flag to `apm install`. It should both be faster and allows people to install great plugins like, `n1-unsubscribe`!

*Currently, users have to install our plugin, reload Nylas, then go back to the plugin page to reactivate the plugin. The error is entirely due to all of the dev-dependencies currently installed by `apm install`, which shouldn't be downloaded anyway. See #2723 for how to reproduce the install problem*

I built and tested the fork locally:
<img width="422" alt="nylas n1 electron today at 6 55 56 am" src="https://cloud.githubusercontent.com/assets/3784339/17807737/6c593b86-65da-11e6-924e-7fcf29504972.png">
