### PR TITLE
use single regex exec for toEquivalentEmailForm

### DIFF
--- a/src/flux/models/utils.coffee
+++ b/src/flux/models/utils.coffee
@@ -224,14 +224,9 @@ Utils =
   # This looks for and removes plus-ing, it taks a VERY liberal approach
   # to match an email address. We'd rather let false positives through.
   toEquivalentEmailForm: (email) ->
-    # https://regex101.com/r/iS7kD5/1
-    localPart1 = /([^+]+?)[+@].*/gi.exec(email)?[1] ? ""
-
-    # https://regex101.com/r/iS7kD5/2
-    domainPart1 = /@(.+)/gi.exec(email)?[1] ? ""
-
-    email = "#{localPart1}@#{domainPart1}".trim().toLowerCase()
-    return email
+    # https://regex101.com/r/iS7kD5/3
+    [_, user, domain] = /^([^+]+).*@(.+)$/gi.exec(email)
+    "#{user}@#{domain}".trim().toLowerCase()
 
   emailIsEquivalent: (email1="", email2="") ->
     return true if email1 is email2


### PR DESCRIPTION
Because I think a single execution should be faster than 2 separate.