### PR TITLE
Error handling for self hosting connect

### DIFF
--- a/internal_packages/onboarding/lib/page-self-hosting-config.jsx
+++ b/internal_packages/onboarding/lib/page-self-hosting-config.jsx
@@ -49,6 +49,9 @@ class SelfHostingConfigPage extends React.Component {
           this.setState({error: "There are no accounts added to this instance of the sync engine. Make sure you've authed an account."})
         }
         OnboardingActions.accountsAddedLocally(accounts)
+      } else {
+        this.setState({error: "Failed to connect to the server, Ready State: " + xmlHttp.readyState +
+                              " Status: " + xmlHttp.status})
       }
     }
     xmlHttp.onerror = () => {


### PR DESCRIPTION
- If the xmlHttp status was not 200 then an error was not returned
- Added an else so if the connection to the server fails the ready state and http status will be displayed as an error
- This will help users debug issues when trying to set up the application and server for development