### PR TITLE
Rename Google Apps to G Suite in onboarding

### DIFF
--- a/internal_packages/onboarding/lib/account-types.es6
+++ b/internal_packages/onboarding/lib/account-types.es6
@@ -2,7 +2,7 @@
 const AccountTypes = [
   {
     type: 'gmail',
-    displayName: 'Gmail or Google Apps',
+    displayName: 'Gmail or G Suite',
     icon: 'ic-settings-account-gmail.png',
     headerIcon: 'setup-icon-provider-gmail.png',
     color: '#e99999',


### PR DESCRIPTION
Google renamed Google Apps (both 'normal' and education editions) to G Suite on 2016-09-29 ([announcement](https://blog.google/products/g-suite/all-together-now-introducing-g-suite/)). Updated text for account selection to match Google's branding.