### PR TITLE
Fix link to Flux diagram in docs/Architecture.md

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -9,7 +9,7 @@ N1 uses [Reflux](https://github.com/spoike/refluxjs), a slim implementation of F
 - **Uni-directional data flow**
 - **Loose coupling between components**
 
-For more information about the Flux pattern, check out [this diagram](https://facebook.github.io/flux/docs/overview.html#structure-and-data-flow). For a bit more insight into why we chose Reflux over other Flux implementations, there's a great [blog post](http://spoike.ghost.io/deconstructing-reactjss-flux/) by the author of Reflux.
+For more information about the Flux pattern, check out [this diagram](https://facebook.github.io/flux/docs/in-depth-overview.html#structure-and-data-flow). For a bit more insight into why we chose Reflux over other Flux implementations, there's a great [blog post](http://spoike.ghost.io/deconstructing-reactjss-flux/) by the author of Reflux.
 
 There are several core stores in the application:
 


### PR DESCRIPTION
Pretty minor change! It looks like the location of the Flux architecture diagrams got moved around on the Flux docs since the last changes on Architecture.md; this change updates the link here to the new/current location of the diagram.